### PR TITLE
Generate and validate ooapi data using clojure.spec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ jobs:
     - name: Run tests
       run: lein test
 
+    - name: Check specs
+      run: lein proof-specs
+
     - name: Run compile
       run: lein uberjar
 

--- a/project.clj
+++ b/project.clj
@@ -4,15 +4,19 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [org.clojure/data.json "2.4.0"]]
+                 [org.clojure/data.json "2.4.0"]
+                 [com.velisco/strgen "0.2.4"]]
   :profiles {:dev {:source-paths ["dev"]
-                   :dependencies [[clj-kondo "2022.05.27"]
-                                  [clj-commons/clj-yaml "0.7.108"]]
+                   :dependencies [[clj-kondo "2022.05.31"]
+                                  [clj-commons/clj-yaml "0.7.108"]
+                                  [nl.jomco/proof-specs "0.1.3"]]
                    :plugins      [[lein-ancient "0.7.0"]]
                    :aliases      {"lint"  ["run" "-m" "clj-kondo.main" "--lint" "src"]
                                   ;; Enums are generated from yaml files in the open-education-api/specification github project.
                                   ;; To regenerate, call `lein generate-enums $path-to-open-education-api-specification`
                                   ;; This will regenerate `src/nl/surf/eduhub_rio_mapper/enums.clj`
-                                  "generate-enums" ["run" "-m" "generate-enums.main"]}}}
-
+                                  "generate-enums" ["run" "-m" "generate-enums.main"]
+                                  "proof-specs" ["run" "-m" "nl.jomco.proof-specs"
+                                                 "--include-regexps" "nl.surf.*"
+                                                 "--require-namespaces" "nl.surf.eduhub-rio-mapper.ooapi,nl.surf.eduhub-rio-mapper.rio"]}}}
   :repl-options {:init-ns nl.surf.eduhub-rio-mapper})

--- a/src/nl/surf/eduhub_rio_mapper/ooapi.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi.clj
@@ -1,36 +1,4 @@
 (ns nl.surf.eduhub-rio-mapper.ooapi
-  (:require [clojure.spec.alpha :as s]
-            [nl.surf.eduhub-rio-mapper.ooapi.LanguageTypedString :as-alias LanguageTypedString])
-  (:import (java.time.format DateTimeFormatter DateTimeParseException)
-           (java.time LocalDate)
-           (java.util UUID)))
-
-;; Patterns
-(def language-code-pattern #"^[a-z]{2,4}(-[A-Z][a-z]{3})?(-([A-Z]{2}|[0-9]{3}))?$")
-(def date-format (DateTimeFormatter/ofPattern "uuuu-MM-dd"))
-
-;; Validators
-(defn valid-date? [date]
-  (and (string? date)
-       (try (LocalDate/parse date date-format)
-            true
-            (catch DateTimeParseException _ false))))
-
-(defn valid-uuid? [uuid]
-  (and (string? uuid)
-       (try (UUID/fromString uuid)
-            true
-            (catch IllegalArgumentException _ false))))
-
-;; Common types
-
-(s/def ::LanguageTypedString/language
-  (s/and string?
-         #(re-matches language-code-pattern %)))
-
-(s/def ::LanguageTypedString/value string?)
-
-(s/def ::LanguageTypedStrings
-  (s/coll-of
-    (s/keys :req-un [::LanguageTypedString/language
-                     ::LanguageTypedString/value])))
+  (:require [nl.surf.eduhub-rio-mapper.ooapi.education-specification]
+            [nl.surf.eduhub-rio-mapper.ooapi.course]
+            [nl.surf.eduhub-rio-mapper.ooapi.program]))

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
@@ -1,0 +1,41 @@
+(ns nl.surf.eduhub-rio-mapper.ooapi.common
+  "Common specs for use in the ooapi namespaces."
+  (:require [clojure.spec.alpha :as s]
+            [nl.surf.eduhub-rio-mapper.ooapi.LanguageTypedString :as-alias LanguageTypedString]
+            [nl.surf.eduhub-rio-mapper.re-spec :refer [re-spec]])
+  (:import (java.time.format DateTimeFormatter DateTimeParseException)
+           (java.time LocalDate)
+           (java.util UUID)))
+
+(def date-format (DateTimeFormatter/ofPattern "uuuu-MM-dd"))
+
+(defn valid-date? [date]
+  (and (string? date)
+       (try (LocalDate/parse date date-format)
+            true
+            (catch DateTimeParseException _ false))))
+
+(s/def ::date
+  (s/and (re-spec #"\d\d\d\d-[01]\d-[012]\d")
+         valid-date?))
+
+(defn valid-uuid? [uuid]
+  (try (UUID/fromString uuid)
+       true
+       (catch IllegalArgumentException _ false)))
+
+(s/def ::uuid
+  (s/and (re-spec #"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+         valid-uuid?))
+
+;; Common types
+
+(s/def ::LanguageTypedString/language
+  (re-spec #"^[a-z]{2,4}(-[A-Z][a-z]{3})?(-([A-Z]{2}|[0-9]{3}))?$"))
+
+(s/def ::LanguageTypedString/value string?)
+
+(s/def ::LanguageTypedStrings
+  (s/coll-of
+    (s/keys :req-un [::LanguageTypedString/language
+                     ::LanguageTypedString/value])))

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/course.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/course.clj
@@ -1,9 +1,9 @@
 (ns nl.surf.eduhub-rio-mapper.ooapi.course
   (:require [clojure.spec.alpha :as s]
             [nl.surf.eduhub-rio-mapper.ooapi.Course :as-alias Course]
-            [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]))
+            [nl.surf.eduhub-rio-mapper.ooapi.common :as common]))
 
-(s/def ::Course/name ::ooapi/LanguageTypedStrings)
+(s/def ::Course/name ::common/LanguageTypedStrings)
 
 (s/def ::Course
   (s/keys :req-un [::Course/name]

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/education_specification.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/education_specification.clj
@@ -3,17 +3,12 @@
             [nl.surf.eduhub-rio-mapper.ooapi.EducationSpecification :as-alias EducationSpecification]
             [nl.surf.eduhub-rio-mapper.ooapi.StudyLoadDescriptor :as-alias StudyLoadDescriptor]
             [nl.surf.eduhub-rio-mapper.ooapi.enums :as enums]
-            [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
-            [clojure.string :as string]))
+            [nl.surf.eduhub-rio-mapper.ooapi.common :as common]
+            [nl.surf.eduhub-rio-mapper.re-spec :refer [re-spec]]))
 
-
-(defn valid-codeType?
-  "codeType should be in a predefined set or start with x-"
-  [codeType]
-  (or (contains? enums/codeTypes codeType)
-      (string/starts-with? codeType "x-")))
-
-(s/def ::EducationSpecification/codeType valid-codeType?)
+(s/def ::EducationSpecification/codeType
+  (s/or :predefined enums/codeTypes
+        :custom (re-spec #"x-[\w.]+")))
 (s/def ::EducationSpecification/code string?)
 
 (s/def ::EducationSpecification/codeTuple
@@ -21,27 +16,27 @@
 
 ;; Top level response keys
 (s/def ::EducationSpecification/abbreviation (s/and string? #(< (count %) 256)))
-(s/def ::EducationSpecification/children (s/coll-of ooapi/valid-uuid?))
-(s/def ::EducationSpecification/description ::ooapi/LanguageTypedStrings)
+(s/def ::EducationSpecification/children (s/coll-of ::common/uuid))
+(s/def ::EducationSpecification/description ::common/LanguageTypedStrings)
 (s/def ::EducationSpecification/educationSpecificationId string?)
 (s/def ::EducationSpecification/educationSpecificationSubType #{"variant"})
 (s/def ::EducationSpecification/educationSpecificationType enums/educationSpecificationTypes)
-(s/def ::EducationSpecification/fieldsOfStudy (s/and string? #(re-matches #"\d{1,4}" %)))
+(s/def ::EducationSpecification/fieldsOfStudy (re-spec #"\d{1,4}"))
 (s/def ::EducationSpecification/formalDocument enums/formalDocumentTypes)
-(s/def ::EducationSpecification/learningOutcomes (s/coll-of ::ooapi/LanguageTypedStrings))
+(s/def ::EducationSpecification/learningOutcomes (s/coll-of ::common/LanguageTypedStrings))
 (s/def ::EducationSpecification/level enums/levels)
 (s/def ::EducationSpecification/levelOfQualification #{"1" "2" "3" "4" "4+" "5" "6" "7" "8"})
-(s/def ::EducationSpecification/name ::ooapi/LanguageTypedStrings)
+(s/def ::EducationSpecification/name ::common/LanguageTypedStrings)
 (s/def ::EducationSpecification/link (s/and string? #(< (count %) 2048)))
 (s/def ::EducationSpecification/otherCodes (s/coll-of ::EducationSpecification/codeTuple))
-(s/def ::EducationSpecification/parent ooapi/valid-uuid?)
+(s/def ::EducationSpecification/parent ::common/uuid)
 (s/def ::EducationSpecification/primaryCode ::EducationSpecification/codeTuple)
 (s/def ::EducationSpecification/sector enums/sectors)
 (s/def ::StudyLoadDescriptor/value number?)
 (s/def ::StudyLoadDescriptor/studyLoadUnit enums/studyLoadUnits)
 (s/def ::EducationSpecification/studyLoad (s/keys :req-un [::StudyLoadDescriptor/studyLoadUnit ::StudyLoadDescriptor/value]))
-(s/def ::EducationSpecification/validFrom ooapi/valid-date?)
-(s/def ::EducationSpecification/validTo ooapi/valid-date?)
+(s/def ::EducationSpecification/validFrom ::common/date)
+(s/def ::EducationSpecification/validTo ::common/date)
 
 (defn valid-type-and-subtype?
   "EducationSpecification should only have subType if type is 'program'."
@@ -76,6 +71,6 @@
          valid-type-and-subtype?))
 
 (s/def ::EducationSpecificationTopLevel
-  (s/and ::EducationSpecification
+  (s/merge ::EducationSpecification
          (s/keys :req-un [::EducationSpecification/validFrom]
                  :opt-un [::EducationSpecification/validTo])))

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/program.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/program.clj
@@ -1,9 +1,9 @@
 (ns nl.surf.eduhub-rio-mapper.ooapi.program
   (:require [clojure.spec.alpha :as s]
             [nl.surf.eduhub-rio-mapper.ooapi.Program :as-alias Program]
-            [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]))
+            [nl.surf.eduhub-rio-mapper.ooapi.common :as common]))
 
-(s/def ::Program/name ::ooapi/LanguageTypedStrings)
+(s/def ::Program/name ::common/LanguageTypedStrings)
 
 (s/def ::Program
   (s/keys :req-un [::Program/name]

--- a/src/nl/surf/eduhub_rio_mapper/re_spec.clj
+++ b/src/nl/surf/eduhub_rio_mapper/re_spec.clj
@@ -1,0 +1,14 @@
+(ns nl.surf.eduhub-rio-mapper.re-spec
+  "Define a spec with a generator for a regular expression."
+  (:require [clojure.spec.alpha :as s]
+            [miner.strgen :as strgen]))
+
+(defn regexp?
+  [x]
+  (instance? java.util.regex.Pattern x))
+
+(defn re-spec
+  "Defines a spec with a genrator for regular expression `re`."
+  [re]
+  (s/spec (s/and string? #(re-matches re %))
+          :gen #(strgen/string-generator re)))


### PR DESCRIPTION
This will allow us to generate ooapi test data using clojure.spec. The
idea is that we can then use those generators to validate the output
against the XSD specification of the RIO API.

For now this only ensures that all the specs have working
generators. `lein check` will try to generate data for each spec in
the project and report on any issues.