### PR TITLE
Job workers

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -3,4 +3,6 @@
   :single-key-in {:level :warning}
   :docstring-no-summary {:level :warning}
   :used-underscored-binding {:level :warning}}
- :lint-as {nl.surf.eduhub-rio-mapper.errors/result-> clojure.core/some->}}
+ :lint-as {nl.surf.eduhub-rio-mapper.errors/result-> clojure.core/some->
+           nl.surf.eduhub-rio-mapper.redis/defcmd clojure.core/def
+           nl.surf.eduhub-rio-mapper.redis/defcmd+ clojure.core/def}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,14 @@ jobs:
     - name: Run tests
       run: lein test
 
+    - name: Start Redis
+      uses: supercharge/redis-github-action@1.4.0
+      with:
+        redis-version: 6.2
+
+    - name: Run tests with redis
+      run: lein test :redis
+
     - name: Proof data specs
       run: lein proof-specs
 

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,9 @@
                  [org.clojure/data.json "2.4.0"]
                  [org.clojure/data.xml "0.0.8"]
                  [org.clojure/tools.cli "1.0.206"]
-                 [org.clojure/tools.logging "1.2.4"]]
+                 [org.clojure/tools.logging "1.2.4"]
+                 [org.clojure/core.async "1.5.648"]
+                 [com.taoensso/carmine "3.1.0"]]
   :java-source-paths ["src"]
   :profiles {:dev {:source-paths ["dev"]
                    :dependencies [[clj-commons/clj-yaml "0.7.110"]
@@ -39,4 +41,7 @@
                                   "proof-specs"    ["run" "-m" "nl.jomco.proof-specs"
                                                     "--include-regexps" "nl.surf.*"
                                                     "--require-namespaces" "nl.surf.eduhub-rio-mapper.ooapi,nl.surf.eduhub-rio-mapper.rio"]}}}
+  :test-selectors {:default (complement :redis)
+                   :redis   :redis
+                   :all     (constantly true)}
   :repl-options {:init-ns nl.surf.eduhub-rio-mapper.ooapi})

--- a/src/nl/surf/eduhub_rio_mapper/redis.clj
+++ b/src/nl/surf/eduhub_rio_mapper/redis.clj
@@ -1,0 +1,28 @@
+(ns nl.surf.eduhub-rio-mapper.redis
+  (:require [clojure.string :refer [upper-case]]
+            [taoensso.carmine :as car :refer [wcar]]
+            [taoensso.carmine.commands :as carcmd])
+  (:refer-clojure :exclude [get set]))
+
+(defmacro defcmd [n]
+  (let [cmd (intern 'taoensso.carmine n)]
+    `(defn ~n [conn# & args#]
+       (wcar conn# (apply ~cmd args#)))))
+
+(defcmd del)
+(defcmd get)
+(defcmd set)
+(defcmd rpush)
+(defcmd lpush)
+(defcmd lpop)
+(defcmd lrange)
+
+(defmacro defcmd+ [n]
+  `(let [cmd# (with-meta
+               (fn [& x#]
+                 (carcmd/enqueue-request 1 (into [~(upper-case (name n))] x#)))
+               {:redis-api true})]
+     (defn ~n [conn# & args#]
+       (wcar conn# (apply cmd# args#)))))
+
+(defcmd+ lmove) ; since redis 6.2.0

--- a/src/nl/surf/eduhub_rio_mapper/worker.clj
+++ b/src/nl/surf/eduhub_rio_mapper/worker.clj
@@ -1,0 +1,270 @@
+(ns nl.surf.eduhub-rio-mapper.worker
+  (:require [clojure.core.async :as async]
+            [nl.surf.eduhub-rio-mapper.redis :as redis]
+            [taoensso.carmine :as car])
+  (:import java.util.UUID))
+
+(defn- prefix-key
+  [{:keys [redis-key-prefix]
+    :or {redis-key-prefix "eduhub-rio-mapper.jobs"}}
+   key]
+  (str redis-key-prefix ":" key))
+
+(defn- lock-name [config k]
+  (prefix-key config (str "lock:" k)))
+
+(defn acquire-lock!
+  "Acquire lock `k` with `ttl-ms`.
+  Return a unique token which can be used to release / extend the
+  lock or `nil` when lock is already taken."
+  [{:keys [redis-conn] :as config}
+   k ttl-ms]
+  (let [k     (lock-name config k)
+        token (str (UUID/randomUUID))]
+    (when (= "OK" (redis/set redis-conn k token "NX" "PX" ttl-ms))
+      token)))
+
+(defn release-lock!
+  "Release lock `k`.
+  Uses `token` to verify if the lock is still ours and throws an
+  exception when it's not."
+  [{:keys [redis-conn] :as config}
+   k token]
+  (let [k (lock-name config k)]
+    (when-not
+      (car/wcar redis-conn
+                (car/parse-bool
+                 (car/lua "if redis.call('get', _:k) == _:token then
+                             redis.call('del', _:k);
+                             return 1;
+                           else
+                             return 0;
+                           end"
+                          {:k k} {:token token})))
+      (throw (ex-info "Lock lost before release!" {:lock-name k})))))
+
+(defn extend-lock!
+  "Extend TTL on lock `k` with `token` by `ttl-ms`.
+  Uses `token` to verify if the lock is still ours and throws an
+  exception when it's not."
+  [{:keys [redis-conn] :as config}
+   k token ttl-ms]
+  (let [k (lock-name config k)]
+    (when-not
+      (car/wcar redis-conn
+                (car/parse-bool
+                 (car/lua "if redis.call('get', _:k) == _:token then
+                             redis.call('set', _:k, _:token, 'px', _:ttl-ms);
+                             return 1;
+                           else
+                             return 0;
+                           end"
+                          {:k k} {:token token, :ttl-ms ttl-ms})))
+      (throw (ex-info "Lock lost before extend!" {:lock-name k})))))
+
+(defn- queue-key [config institution-id]
+  (prefix-key config (str "queue:" institution-id)))
+
+(defn- busy-queue-key [config institution-id]
+  (prefix-key config (str "busy-queue:" institution-id)))
+
+(defn- set-status!
+  "Set status of job.
+  Should only be called by worker, not by job itself!"
+  [config job status & payload]
+  (comment "TODO" config job status payload))
+
+(defn- add-to-queue!
+  [{:keys [redis-conn] :as config}
+   {:keys [institution-id] :as job}
+   side]
+  ((case side
+     :left redis/lpush
+     :right redis/rpush)
+   redis-conn (queue-key config institution-id) job)
+  (set-status! config job :pending)
+  job)
+
+(defn queue!
+  "Queue a job."
+  [config job]
+  (add-to-queue! config job :right))
+
+(defn queue-first!
+  "Queue a job in front of the queue."
+  [config job]
+  (add-to-queue! config job :left))
+
+(defn- pop-job!
+  "Pop job from an institution queue.
+  The job is stored on the institution busy queue to allow restarting
+  when aborted.  Returns a job or `nil` when queue is empty."
+  [{:keys [redis-conn] :as config}
+   institution-id]
+  (redis/lmove redis-conn
+               (queue-key config institution-id)
+               (busy-queue-key config institution-id)
+               "LEFT"
+               "RIGHT"))
+
+(defn- occupied-queues
+  "Return list of institution ids having jobs queued."
+  [{:keys [redis-conn institution-ids] :as config}]
+  (let [script (apply str "local ids = {};"
+                      (conj
+                       (mapv #(str "if redis.call('llen', _:i" % ") > 0 then
+                                      table.insert(ids, _:v" % ")
+                                    end;")
+                             (range (count institution-ids)))
+                       "return ids;"))
+        ks   (into {} (map #(vector (keyword (str "i" %1))
+                                    (queue-key config %2))
+                           (range (count institution-ids))
+                           institution-ids))
+        vs   (into {} (map #(vector (keyword (str "v" %1)) %2)
+                           (range (count institution-ids))
+                           institution-ids))]
+    (car/wcar redis-conn (car/lua script ks vs))))
+
+(defn- recover-aborted-job!
+  "Recover aborted job, when available, and queue it."
+  [{:keys [redis-conn] :as config}
+   institution-id]
+  (redis/lmove redis-conn
+               (busy-queue-key config institution-id)
+               (queue-key config institution-id)
+               "RIGHT"
+               "LEFT"))
+
+(defn- job-done!
+  "Remove job from busy queue."
+  [{:keys [redis-conn] :as config}
+   institution-id]
+  (redis/lpop redis-conn (busy-queue-key config institution-id)))
+
+(defn- run-job!
+  "Execute job."
+  [config job]
+  (comment "TODO" config job))
+
+(defn- nack?
+  "Returns `true` when a job failed but is retryable."
+  [job result]
+  (comment "TODO" job result))
+
+(defn- error?
+  "Returns `true` when job resulted in an error."
+  [job result]
+  (comment "TODO" job result))
+
+(defn- worker-loop
+  "Worker loop.
+
+  It loops through list of institutions and tries to acquire a lock
+  for them to do work (this ensures jobs are run in order for an
+  institution).  When the lock has been acquired it pops a job from
+  the queue and runs it.  If the job failed but can be restarted (see
+  also `nack?`), we waits `retry-wait-ms` and puts the job back in the
+  front of the queue.
+
+  The config options `nack?` and `run-job!` are here to allow
+  overriding these functions for writing tests."
+  [{:keys  [institution-ids
+            lock-ttl-ms
+            max-retries
+            nap-ms
+            retry-wait-ms]
+    ::keys [nack? run-job!] ;; overrides for testing
+    :or    {lock-ttl-ms   10000
+            max-retries   3
+            nack?         nack?
+            nap-ms        1000
+            retry-wait-ms 5000
+            run-job!      run-job!}
+    :as    config}
+   stop-atom]
+  (assert (seq institution-ids))
+
+  (let [timeout-ms (/ lock-ttl-ms 2)]
+    (loop [ids (occupied-queues config)]
+      (if-let [[id & ids] ids]
+        (do
+          ;; try and acquire lock of institution
+          (when-let [token (some-> (acquire-lock! config id lock-ttl-ms) atom)]
+            (try
+              ;; recover jobs which have been aborted
+              (recover-aborted-job! config id)
+
+              (when-let [job (pop-job! config id)]
+                ;; run job asynchronous
+                (let [c (async/thread
+                          (.setName (Thread/currentThread) (str "runner-" id))
+                          (run-job! config job))]
+                  (set-status! config job :in-progress)
+
+                  ;; wait for job to finish and refresh lock regularly
+                  ;; while waiting
+                  (loop []
+                    (let [r (async/alt!! c ([v] v)
+                                         (async/timeout timeout-ms) ::ping)]
+                      (extend-lock! config id @token lock-ttl-ms)
+
+                      (if (= ::ping r)
+                        (recur)
+                        (if (nack? job r)
+                          (if (and (::retries job) (>= (::retries job) max-retries))
+                            (set-status! config job :time-out)
+                            (do
+                              (queue-first! config (update job ::retries (fnil inc 0)))
+                              ;; extend lock lease to retry-wait
+                              (extend-lock! config id @token retry-wait-ms)
+                              ;; prevent release
+                              (reset! token nil)))
+
+                          ;; ack
+                          (if (error? job r)
+                            (set-status! config job :error r)
+                            (set-status! config job :done r)))))))
+
+                ;; done, remove from busy
+                (job-done! config id))
+
+              (finally
+                (some->> @token (release-lock! config id)))))
+
+          (when-not @stop-atom
+            ;; next institution
+            (recur ids)))
+        (when-not @stop-atom
+          ;; do nothing for a while to give redis a rest
+          (async/<!! (async/timeout nap-ms))
+
+          ;; start all over
+          (recur (occupied-queues config)))))))
+
+(defn start-worker!
+  "Start a worker loop asynchronously.
+  Returns an atom and go block channel which can be used by
+  `stop-worker!` to stop the created worker."
+  [config]
+  (let [stop-atom (atom nil)]
+    [stop-atom
+     (async/thread
+       (.setName (Thread/currentThread) "worker")
+       (worker-loop config stop-atom)
+       :stopped)]))
+
+(defn stop-worker!
+  "Signal worker to stop and wait for it to finish."
+  [[stop-atom chan]]
+  (reset! stop-atom true)
+  (async/<!! chan))
+
+(defn purge!
+  "Delete all queues and locks."
+  [{:keys [redis-conn institution-ids]
+    :as config}]
+  (doseq [institution-id institution-ids]
+    (redis/del redis-conn (queue-key config institution-id))
+    (redis/del redis-conn (busy-queue-key config institution-id))
+    (redis/del redis-conn (lock-name config institution-id))))

--- a/test/nl/surf/eduhub_rio_mapper/worker_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/worker_test.clj
@@ -1,0 +1,143 @@
+(ns nl.surf.eduhub-rio-mapper.worker-test
+  (:require [nl.surf.eduhub-rio-mapper.worker :as worker]
+            [clojure.test :refer :all]))
+
+(def config
+  {:redis-conn        {:pool {} :spec {:uri "redis://localhost"}}
+   :prefix-key-prefix "eduhub-rio-mapper.worker-test"
+   :institution-ids   ["foo" "bar"]
+   :nap-ms            10
+   :retry-wait-ms     10})
+
+(defn wait-for-expected [expected val-atom max-sec]
+  (loop [ttl (* max-sec 10)]
+    (when (and (pos? ttl) (not= expected @val-atom))
+      (Thread/sleep 100)
+      (recur (dec ttl))))
+  (is (= expected @val-atom)))
+
+(deftest ^:redis worker
+  (let [job-runs (atom {"foo" [], "bar" []})
+        config   (-> config
+                     (assoc ::worker/run-job!
+                            (fn [_ {:keys [institution-id job-nr]}]
+                              (swap! job-runs update institution-id conj job-nr))))]
+    (worker/purge! config)
+
+    ;; queue some without running workers
+    (doseq [n (range 100)]
+      (worker/queue! config {:institution-id "foo", :job-nr n}))
+    (doseq [n (range 50)]
+      (worker/queue! config {:institution-id "bar", :job-nr n}))
+
+    ;; spin up a bunch of workers
+    (let [workers (mapv (fn [_] (worker/start-worker! config)) (range 100))]
+
+      ;; wait till work is done and check it
+      (let [expected {"foo" (range 100)
+                      "bar" (range 50)}]
+        (wait-for-expected expected job-runs 30))
+
+      ;; queue more work
+      (doseq [n (range 100 200)]
+        (worker/queue! config {:institution-id "foo", :job-nr n}))
+      (doseq [n (range 50 100)]
+        (worker/queue! config {:institution-id "bar", :job-nr n}))
+
+      ;; wait till work is done and check it
+      (let [expected {"foo" (range 200)
+                      "bar" (range 100)}]
+        (wait-for-expected expected job-runs 30)
+        (is (= expected @job-runs)))
+
+      ;; stop workers
+      (doseq [worker workers] (worker/stop-worker! worker))
+      (worker/purge! config))))
+
+(deftest ^:redis all-retries
+  (let [last-seen-job (atom nil)
+        max-retries   3
+        config        (-> config
+                          (assoc :max-retries max-retries)
+                          (assoc ::worker/run-job!
+                                 (fn [_ job]
+                                   (reset! last-seen-job job)
+                                   :from-job))
+                          (assoc ::worker/nack?
+                                 (fn [_job result]
+                                   (= result :from-job))))]
+    (worker/purge! config)
+
+    ;; spin up a bunch of workers
+    (let [workers (mapv (fn [_] (worker/start-worker! config)) (range 100))]
+      ;; queue a nacking job
+      (worker/queue! config {:institution-id "foo"})
+
+      ;; wait job to finish and check it
+      (let [expected {:institution-id  "foo"
+                      ::worker/retries max-retries}]
+        (wait-for-expected expected last-seen-job 5))
+
+      ;; stop workers
+      (doseq [worker workers] (worker/stop-worker! worker))
+      (worker/purge! config))))
+
+(deftest ^:redis two-retries
+  (let [last-seen-job (atom nil)
+        max-retries   3
+        config        (-> config
+                          (assoc :max-retries max-retries)
+                          (assoc ::worker/run-job!
+                                 (fn [_ job]
+                                   (reset! last-seen-job job)
+                                   (::worker/retries job)))
+                          (assoc ::worker/nack?
+                                 (fn [_ result]
+                                   (not= 2 result))))]
+    (worker/purge! config)
+
+    ;; spin up a bunch of workers
+    (let [workers (mapv (fn [_] (worker/start-worker! config)) (range 100))]
+      ;; queue a nacking job
+      (worker/queue! config {:institution-id "foo"})
+
+      ;; wait job to finish and check it
+      (let [expected {:institution-id  "foo"
+                      ::worker/retries 2}]
+        (wait-for-expected expected last-seen-job 5))
+
+      ;; stop workers
+      (doseq [worker workers] (worker/stop-worker! worker))
+      (worker/purge! config))))
+
+(deftest ^:redis retry-wait
+  (let [last-seen-job (atom nil)
+        retry-wait-ms 3000
+        config        (-> config
+                          (assoc :retry-wait-ms retry-wait-ms)
+                          (assoc ::worker/run-job!
+                                 (fn [_ job]
+                                   (reset! last-seen-job job)
+                                   (::worker/retries job)))
+                          (assoc ::worker/nack?
+                                 (fn [_ result]
+                                   (not= 1 result))))]
+    (worker/purge! config)
+
+    ;; spin up a bunch of workers
+    (let [workers (mapv (fn [_] (worker/start-worker! config)) (range 100))]
+
+      ;; queue a job to be retried once
+      (worker/queue! config {:institution-id "foo"})
+
+      (let [before-ms (System/currentTimeMillis)
+            expected  {:institution-id  "foo"
+                       ::worker/retries 1}]
+        (wait-for-expected expected last-seen-job 10)
+        (is (>= (- (System/currentTimeMillis) before-ms)
+                retry-wait-ms)
+            "wall time should be at least retry-wait-ms"))
+
+      ;; stop workers
+      (doseq [worker workers] (worker/stop-worker! worker))
+      (worker/purge! config))))


### PR DESCRIPTION
A job worker which loops through institution list and tries to get an exclusive lock for a institution.  Having a lock it runs a job from the institution's job queue and goes on to the next institution.  If a job fails, but is retryable, it is rescheduled.

Multiple instances of this worker can be started.  Locks and queues are stored in redis.  Use `lein test :redis` to run the tests.