### PR TITLE
Allow more than one element in rio-sexp.

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/rio/mutator.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/mutator.clj
@@ -38,8 +38,9 @@
   [{:keys [root-url recipient-oin credentials]} request-poster]
   {:pre [(some? (:certificate credentials))]}
   (fn mutator [{:keys [action sender-oin rio-sexp]}]
+    {:pre [(vector? (first rio-sexp))]}
     (let [datamap (make-datamap sender-oin recipient-oin)
-          xml-or-errors (soap/prepare-soap-call action [rio-sexp] datamap credentials)
+          xml-or-errors (soap/prepare-soap-call action rio-sexp datamap credentials)
           response-element-name (str "ns2:" action "_response")
           url (str root-url "beheren4.0")]
       (when-let [xml (guard-errors xml-or-errors (str "Error preparing " action))]

--- a/src/nl/surf/eduhub_rio_mapper/updated_handler.clj
+++ b/src/nl/surf/eduhub_rio_mapper/updated_handler.clj
@@ -54,19 +54,19 @@ education specification.")
         {:action "aanleveren_opleidingseenheid"
          :ooapi entity
          :sender-oin institution-oin
-         :rio-sexp (opl-eenh/education-specification->opleidingseenheid entity)}
+         :rio-sexp [(opl-eenh/education-specification->opleidingseenheid entity)]}
 
         "course"
         {:action "aanleveren_aangebodenOpleiding"
          :ooapi entity
          :sender-oin institution-oin
-         :rio-sexp (aangeboden-opl/course->aangeboden-opleiding entity opleidingscode)}
+         :rio-sexp [(aangeboden-opl/course->aangeboden-opleiding entity opleidingscode)]}
 
         "program"
         {:action "aanleveren_aangebodenOpleiding"
          :ooapi entity
          :sender-oin institution-oin
-         :rio-sexp (aangeboden-opl/program->aangeboden-opleiding entity (:educationSpecificationType education-specification) opleidingscode)}))))
+         :rio-sexp [(aangeboden-opl/program->aangeboden-opleiding entity (:educationSpecificationType education-specification) opleidingscode)]}))))
 
 (defn deleted-handler
   "Returns a RIO call or errors."
@@ -77,7 +77,7 @@ education specification.")
     (if opleidingscode
       {:action "verwijderen_opleidingseenheid"
        :sender-oin institution-oin
-       :rio-sexp [:duo:opleidingseenheidcode opleidingscode]}
+       :rio-sexp [[:duo:opleidingseenheidcode opleidingscode]]}
       {:errors "Geen opleidingseenheid bekend voor opgegeven education-specification"
        :id id
        :type type})
@@ -85,4 +85,4 @@ education specification.")
     ("course" "program")
     {:action "verwijderen_aangebodenOpleiding"
      :sender-oin institution-oin
-     :rio-sexp [:duo:aangebodenOpleidingCode id]}))
+     :rio-sexp [[:duo:aangebodenOpleidingCode id]]}))

--- a/test/nl/surf/eduhub_rio_mapper/rio_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/rio_test.clj
@@ -32,7 +32,7 @@
 
 (defn prep-body
   [{:keys [action rio-sexp]}]
-  (soap/request-body action [rio-sexp] "http://duo.nl/schema/DUO_RIO_Beheren_OnderwijsOrganisatie_V4"))
+  (soap/request-body action rio-sexp "http://duo.nl/schema/DUO_RIO_Beheren_OnderwijsOrganisatie_V4"))
 
 (def test-handler
   "Loads ooapi fixtures from file and fakes resolver."


### PR DESCRIPTION
Needed for verwijderen_opleidingsrelatie, which takes three arguments.
