### PR TITLE
Command line support to show ooapi-entity.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -106,6 +106,34 @@ the OOAPI endpoint, type and ID.  An example:
 lein mapper delete uni-id course 123e4567-e89b-12d3-a456-426655440000
 ```
 
+### show
+
+The `show` command retrieves data from OOAPI. The following entities are supported:
+
+#### course
+
+Example:
+
+```sh
+lein mapper show uni-id course 123e4567-e89b-12d3-a456-426655440000
+```
+
+#### program
+
+Example:
+
+```sh
+lein mapper show uni-id program 123e4567-e89b-12d3-a456-426655440000
+```
+
+#### education-specification
+
+Example:
+
+```sh
+lein mapper show uni-id education-specification 123e4567-e89b-12d3-a456-426655440000
+```
+
 ### get
 
 The `get` command retrieves data from RIO. The following actions are

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
@@ -65,6 +65,7 @@
 (defn make-ooapi-http-loader
   [root-url credentials]
   (fn [context]
+    {:pre [(:institution-schac-home context)]}
     (ooapi-http-loader (assoc context
                               ::ooapi/root-url root-url
                               :gateway-credentials credentials))))


### PR DESCRIPTION
This can be used to query e.g. WUR. Useful now that there are ooapi-implementations behind gateway authentication and cannot be queried directly as easily as the demo04 test servers.