### PR TITLE
Narrow down detailed fieldsOfStudy for RIO

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
@@ -112,9 +112,11 @@
 (s/def ::StudyLoadDescriptor/studyLoadUnit enums/studyLoadUnits)
 (s/def ::studyLoad (s/keys :req-un [::StudyLoadDescriptor/studyLoadUnit ::StudyLoadDescriptor/value]))
 
-;; TODO: Check this: XSD says 0-999 for ISCED, original spec def was 4
-;; digits.
-(s/def ::fieldsOfStudy (re-spec #"0*\d{1,3}"))
+;; XSD says 0-999 for ISCED, so broad/narrow fields.  OOAPI spec def
+;; is 4 digits, so it accepts detailed fields. See also
+;; `nl.surf.eduhub-rio-mapper.rio/narrow-isced`
+(s/def ::fieldsOfStudy (re-spec #"\d{1,4}"))
+
 (s/def ::learningOutcomes (s/coll-of ::LanguageTypedStrings))
 (s/def ::level enums/levels)
 (s/def ::levelOfQualification #{"1" "2" "3" "4" "4+" "5" "6" "7" "8"})

--- a/src/nl/surf/eduhub_rio_mapper/rio.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio.clj
@@ -66,6 +66,21 @@
    :number  :duo:kenmerkwaardeGetal
    :boolean :duo:kenmerkwaardeBoolean})
 
+(defn narrow-isced
+  "When given an ISCED-F detailed field, return the narrow version."
+  [s]
+  (when s
+    (if (< (count s) 4)
+      s
+      ;; Last digit is the detailed info, we can remove it
+      ;; See also
+      ;;
+      ;; ISCED FIELDS OF EDUCATION AND TRAINING 2013 (ISCED-F 2013)
+      ;; Appendix I. ISCED fields of education and training
+      ;;
+      ;; http://uis.unesco.org/sites/default/files/documents/isced-fields-of-education-and-training-2013-en.pdf
+      (subs s 0 3))))
+
 (defn kenmerken [name type value]
   (when value
      [:duo:kenmerken

--- a/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
@@ -41,7 +41,6 @@
    :buitenlandsePartner [:foreignPartners true]
    :eersteInstroomDatum [:firstStartDate false]
    :einddatum [:validTo false]
-   :ISCED [:fieldsOfStudy false]
    :onderwijsaanbiedercode [:educationOffererCode true]
    :onderwijslocatiecode [:educationLocationCode false]
    :opleidingseenheidSleutel [::rio/opleidingscode false]
@@ -105,7 +104,7 @@
   "Given a course or program, a rio-consumer object and an id, return a function.
    This function, given a attribute name from the RIO namespace, returns the corresponding value from the course or program,
    translated if necessary to the RIO domain."
-  [{:keys [offerings level modeOfStudy sector timelineOverrides] :as course-program}
+  [{:keys [offerings level modeOfStudy sector timelineOverrides fieldsOfStudy] :as course-program}
    {:keys [duration] :as rio-consumer}
    id
    opleidingscode]
@@ -118,6 +117,7 @@
             (rio/ooapi-mapping (name k) (translation (if consumer rio-consumer course-program)))
             (translation (if consumer rio-consumer course-program)))
           (case k
+            :ISCED (rio/narrow-isced fieldsOfStudy)
             :aangebodenOpleidingCode id
             :afwijkendeOpleidingsduur (when duration-map {:opleidingsduurEenheid (:eenheid duration-map)
                                                           :opleidingsduurOmvang (:omvang duration-map)})

--- a/src/nl/surf/eduhub_rio_mapper/rio/opleidingseenheid.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/opleidingseenheid.clj
@@ -34,16 +34,16 @@
 (def ^:private mapping-eduspec->opleidingseenheid
   {:begindatum                    :validFrom
    :einddatum                     :validTo
-   :ISCED                         :fieldsOfStudy
    :eigenOpleidingseenheidSleutel :educationSpecificationId
    :opleidingseenheidcode         :rioId})
 
 (defn- education-specification-adapter
-  [{:keys [category formalDocument level levelOfQualification sector timelineOverrides] :as eduspec}]
+  [{:keys [category formalDocument level levelOfQualification sector timelineOverrides fieldsOfStudy] :as eduspec}]
   (fn [opl-eenh-attr-name]
     (if-let [translation (mapping-eduspec->opleidingseenheid opl-eenh-attr-name)]
       (translation eduspec)
       (case opl-eenh-attr-name
+        :ISCED (rio/narrow-isced fieldsOfStudy)
         :categorie (rio/ooapi-mapping "categorie" category)
         :eqf (rio/ooapi-mapping "eqf" levelOfQualification)
         :niveau (rio/level-sector-mapping level sector)


### PR DESCRIPTION
The OOAPI spec defines a fieldsOfStudy property which is an ISCED-F string with 4 digits (a detailed code). The RIO API takes an ISCED property of a number with range 0-999 (a narrow code). You can convert from detailed to narrow by removing the last digit.

See also ISCED FIELDS OF EDUCATION AND TRAINING 2013 (ISCED-F 2013) - Appendix I. ISCED fields of education and training.

http://uis.unesco.org/sites/default/files/documents/isced-fields-of-education-and-training-2013-en.pdf