### PR TITLE
Always retry exceptions (and unsuccessful http requests)

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/job.clj
+++ b/src/nl/surf/eduhub_rio_mapper/job.clj
@@ -30,11 +30,17 @@
           (logging/log-exception ex error-id)
           {:errors {:error-id error-id
                     :trace-context trace-context
-                    ;; TODO the following is not very accurate
-                    ;; because the mapper does not handle the
-                    ;; unhappy paths very well (http request
-                    ;; responding with 404 etc.
+
+                    ;; TODO the following is not very accurate because
+                    ;; the mapper does not handle the unhappy paths
+                    ;; very well (http request responding with 404
+                    ;; etc.
                     :phase    (case action
                                 "delete" :deleting
                                 "upsert" :upserting)
-                    :message  "RIO Mapper internal error"}})))))
+                    :message  (.getMessage ex)
+
+                    ;; We consider all exceptions retryable because
+                    ;; something unexpected happened and hopefully it
+                    ;; won't next time we try.
+                    :retryable? true}})))))

--- a/src/nl/surf/eduhub_rio_mapper/rio/loader.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/loader.clj
@@ -61,14 +61,9 @@
    :from-url  (str "http://www.w3.org/2005/08/addressing/anonymous?oin=" sender-oin)})
 
 (defn- extract-getter-response
-  [{:keys [success body status]} type]
-  (when-not success
-    (throw (ex-info (str "Invalid http status " status)
-                    {:body body, :status status})))
-
+  [{:keys [body]} type]
   (when-not (re-find (re-pattern (str "ns2:opvragen_" type "_response")) body)
-    (throw (ex-info "Invalid response"
-                    {:body body})))
+    (throw (ex-info "Invalid response" {:body body})))
   body)
 
 (defn- handle-opvragen-request [type request]

--- a/test/nl/surf/eduhub_rio_mapper/job_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/job_test.clj
@@ -1,0 +1,18 @@
+(ns nl.surf.eduhub-rio-mapper.job-test
+  (:require [clojure.test :refer :all]
+            [nl.surf.eduhub-rio-mapper.errors :as errors]
+            [nl.surf.eduhub-rio-mapper.job :as job])
+  (:refer-clojure :exclude [run!]))
+
+(def dummy-handlers {:delete-and-mutate identity, :update-and-mutate identity})
+
+(def dummy-job {:id 0, :type 0, :action "delete", :institution-schac-home 0, :institution-oin 0})
+
+(deftest run!
+  (testing "throwing an exception"
+    (let [msg      "yelp"
+          handlers (assoc dummy-handlers :delete-and-mutate (fn [_] (throw (Exception. msg))))]
+      (is (errors/retryable? (job/run! handlers dummy-job))
+          "throwing an exception results a retryable error")
+      (is (= msg (-> (job/run! handlers dummy-job) :errors :message))
+          "throwing an exception results a retryable error"))))

--- a/test/nl/surf/eduhub_rio_mapper/mapper_integration_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/mapper_integration_test.clj
@@ -48,7 +48,7 @@
                                 :institution-oin institution-oin})]
     (if (errors? result)
       result
-      (let [mutator (mutator/make-mutator (:rio-config config) (constantly {:status 200 :success true :body xml-response}))]
+      (let [mutator (mutator/make-mutator (:rio-config config) (constantly {:status 200 :body xml-response}))]
         (mutator result)))))
 
 (defn- simulate-delete [ooapi-type xml-response]
@@ -56,7 +56,7 @@
   (let [result (mock-handle-deleted ooapi-id ooapi-type institution-oin)]
     (if (errors? result)
       result
-      (let [mutator (mutator/make-mutator (:rio-config config) (constantly {:status 200 :success true :body xml-response}))]
+      (let [mutator (mutator/make-mutator (:rio-config config) (constantly {:status 200 :body xml-response}))]
         (mutator result)))))
 
 (deftest test-handle-updated-eduspec-0


### PR DESCRIPTION
Simplify code by throwing an exception when an http request fails and always retrying a job when it throws an exception.