### PR TITLE
Pass trace-context to worker and http calls

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [commons-io "2.11.0"]
                  [compojure "1.7.0"]
                  [nl.jomco/envopts "0.0.4"]
-                 [nl.jomco/ring-trace-context "0.0.2"]
+                 [nl.jomco/ring-trace-context "0.0.5"]
                  [nl.jomco/clj-http-status-codes "0.1"]
                  [org.apache.santuario/xmlsec "3.0.1" :exclusions [org.slf4j/slf4j-api]]
                  [org.clojure/clojure "1.11.1"]

--- a/src/nl/surf/eduhub_rio_mapper/api.clj
+++ b/src/nl/surf/eduhub_rio_mapper/api.clj
@@ -51,7 +51,8 @@
           (when (and type action)
             {:job (-> request
                       (select-keys [:institution-schac-home
-                                    :institution-oin])
+                                    :institution-oin
+                                    :trace-context])
                       (assoc :action action
                              :type   type
                              :id     id))})))

--- a/src/nl/surf/eduhub_rio_mapper/http_utils.clj
+++ b/src/nl/surf/eduhub_rio_mapper/http_utils.clj
@@ -1,12 +1,13 @@
 (ns nl.surf.eduhub-rio-mapper.http-utils
   (:require [clj-http.client :as http]
             [clojure.tools.logging :as log]
-            [nl.jomco.http-status-codes :as http-status]))
+            [nl.jomco.http-status-codes :as http-status]
+            [nl.jomco.ring-trace-context :as trace-context]))
 
 (defn send-http-request
   [{:keys [content-type method url] :as request}]
   {:pre [url method content-type]}
-  (let [response (-> request
+  (let [request (-> request
                      (assoc :content-type (case content-type
                                             :json
                                             "application/json"
@@ -16,9 +17,14 @@
                             :throw-exceptions false
                             :keystore-type    "jks"
                             :trust-store-type "jks")
-                     http/request)]
-
-
-    (log/debugf "%s; %s; status %s" method url (:status response))
+                     ;; Create a new trace-context from the current one
+                     ;; in scope, and add it to the request
+                     (trace-context/set-context (trace-context/new-context)))
+        response  (http/request request)]
+    (log/debugf "%s - %s; %s; status %s"
+                (get-in request [:headers "traceparent"])
+                method
+                url
+                (:status response))
     (log/trace {:request request :response response})
     (assoc response :success (http-status/success-status? (:status response)))))

--- a/src/nl/surf/eduhub_rio_mapper/job.clj
+++ b/src/nl/surf/eduhub_rio_mapper/job.clj
@@ -1,5 +1,6 @@
 (ns nl.surf.eduhub-rio-mapper.job
   (:require [clojure.tools.logging :as log]
+            [nl.jomco.ring-trace-context :refer [with-context]]
             [nl.surf.eduhub-rio-mapper.logging :as logging]
             [nl.surf.eduhub-rio-mapper.ooapi :as ooapi])
   (:import java.util.UUID)
@@ -8,7 +9,8 @@
 (defn run!
   "Run given job and return result."
   [{:keys [delete-and-mutate update-and-mutate]}
-   {:keys [id type action args institution-schac-home institution-oin]}]
+   {:keys [id type action args institution-schac-home institution-oin
+           trace-context]}]
   {:pre [id type action institution-schac-home institution-oin
          delete-and-mutate update-and-mutate]}
   (log/infof "Started job, action %s, type %s, id %s" action type id)
@@ -19,13 +21,15 @@
              :institution-schac-home institution-schac-home
              :institution-oin        institution-oin}]
     (try
-      (case action
-        "delete" (delete-and-mutate job)
-        "upsert" (update-and-mutate job))
+      (with-context trace-context
+        (case action
+          "delete" (delete-and-mutate job)
+          "upsert" (update-and-mutate job)))
       (catch Exception ex
         (let [error-id (UUID/randomUUID)]
           (logging/log-exception ex error-id)
           {:errors {:error-id error-id
+                    :trace-context trace-context
                     ;; TODO the following is not very accurate
                     ;; because the mapper does not handle the
                     ;; unhappy paths very well (http request

--- a/src/nl/surf/eduhub_rio_mapper/logging.clj
+++ b/src/nl/surf/eduhub_rio_mapper/logging.clj
@@ -79,7 +79,7 @@
 (defn wrap-request-logging
   [f]
   (fn [{:keys                        [request-method uri]
-        {:keys [trace-id parent-id]} :traceparent
+        {:keys [trace-id parent-id]} :trace-context
         :as                          request}]
     (let [method (string/upper-case (name request-method))]
       (with-mdc {:request_method method

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
@@ -47,7 +47,9 @@
                                :req-un [::ooapi/institution-schac-home ::ooapi/gateway-credentials]))
 
 (defn ooapi-http-loader
-  [{::ooapi/keys [root-url type id] :keys [institution-schac-home gateway-credentials] :as ooapi-request}]
+  [{::ooapi/keys [root-url type id]
+    :keys [institution-schac-home gateway-credentials]
+    :as ooapi-request}]
   {:pre [(s/valid? ::ooapi/request ooapi-request)]}
   (let [path    (ooapi-type->path type id)
         request (merge {:url  (str root-url path)


### PR DESCRIPTION
- Adds trace context to queue messages
- Create a new span under the current trace id for any outgoing HTTP calls.
- Return the used top-level traceparent header in the API response

This way we can in principle track anything happening that's triggered by a particular upsert/delete call to the web API, even when that's happening in the worker or on some remote call.