### PR TITLE
Use client middleware for passing trace context

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [commons-io "2.11.0"]
                  [compojure "1.7.0"]
                  [nl.jomco/envopts "0.0.4"]
-                 [nl.jomco/ring-trace-context "0.0.7"]
+                 [nl.jomco/ring-trace-context "0.0.8"]
                  [nl.jomco/clj-http-status-codes "0.1"]
                  [org.apache.santuario/xmlsec "3.0.1" :exclusions [org.slf4j/slf4j-api]]
                  [org.clojure/clojure "1.11.1"]


### PR DESCRIPTION
This refactors the http-utils send-http-request function, using explicit middleware. This way we can also use the middleware from `ring-trace-context`.