### PR TITLE
Add GH action to build docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build docker image
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'v[0-9]+.[0-9]+'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: eduhub-docker-production.artie.ia.surfsara.nl/rio-mapper
+          tags: |
+            type=match,pattern=v\d+.\d+
+            type=sha,format=long
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: eduhub-docker-production.artie.ia.surfsara.nl
+          username: ${{ secrets.ARTIFACTORY_USERNAME }}
+          password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+    tags:
       - 'v[0-9]+.[0-9]+'
 
 jobs:


### PR DESCRIPTION
This PR adds a GH action to build docker images and push them to the SURF Artifactory repository. It will (should) do so on pushes to `main` and pushes with tags following our version numbers `v*.*`.

The relevant secrets have been configured in the respository.