### PR TITLE
Metrics for number of jobs per schac-home

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/api/authentication.clj
+++ b/src/nl/surf/eduhub_rio_mapper/api/authentication.clj
@@ -81,6 +81,9 @@
   (assert (< 0 ttl-minutes))
   (memo/ttl authenticator :ttl/threshold (* 1000 60 ttl-minutes)))
 
+(defn public-request? [request]
+  (= (:uri request) "/metrics"))
+
 (defn wrap-authentication
   "Authenticate calls to ring handler `f` using `token-authenticator`.
 
@@ -94,13 +97,15 @@
   response is returned."
   [f token-authenticator]
   (fn [request]
-    (if-let [token (bearer-token request)]
-      (if-let [client-id (token-authenticator token)]
-        ;; set client-id on request and response (for tracing)
-        (with-mdc {:client-id client-id}
-          (-> request
-              (assoc :client-id client-id)
-              f
-              (assoc :client-id client-id)))
-        (response/status http-status/forbidden))
-      (response/status http-status/unauthorized))))
+    (if (public-request? request)
+      (f request)
+      (if-let [token (bearer-token request)]
+        (if-let [client-id (token-authenticator token)]
+          ;; set client-id on request and response (for tracing)
+          (with-mdc {:client-id client-id}
+                    (-> request
+                        (assoc :client-id client-id)
+                        f
+                        (assoc :client-id client-id)))
+          (response/status http-status/forbidden))
+        (response/status http-status/unauthorized)))))

--- a/src/nl/surf/eduhub_rio_mapper/clients_info.clj
+++ b/src/nl/surf/eduhub_rio_mapper/clients_info.clj
@@ -22,6 +22,7 @@
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
             [nl.jomco.http-status-codes :as http-status]
+            [nl.surf.eduhub-rio-mapper.api.authentication :as authentication]
             [nl.surf.eduhub-rio-mapper.logging :refer [with-mdc]]))
 
 (s/def ::client-info
@@ -72,4 +73,6 @@
             (merge info)
             f
             (merge info)))
-      {:status http-status/forbidden})))
+      (if (authentication/public-request? request)
+        (f request)
+        {:status http-status/forbidden}))))

--- a/src/nl/surf/eduhub_rio_mapper/metrics.clj
+++ b/src/nl/surf/eduhub_rio_mapper/metrics.clj
@@ -1,25 +1,17 @@
 (ns nl.surf.eduhub-rio-mapper.metrics
-  (:require [clojure.string :as str]
-            [nl.surf.eduhub-rio-mapper.redis :as redis]
-            [nl.surf.eduhub-rio-mapper.worker :as worker]))
+  (:require [clojure.string :as str]))
 
 (defn render-metrics [queue-count]
-  {:pre [(every? string? (keys queue-count))
+  {:pre [(map? queue-count)
+         (every? string? (keys queue-count))
          (every? integer? (vals queue-count))]}
   (str/join "\n" (map (fn [[k v]] (format "active_and_queued_job_count{schac_home=\"%s\"} %s" k v))
                       queue-count)))
 
-(defn- count-by-key [query redis-conn]
-  (let [prefix-len (dec (count query))]
-    (->> (redis/keys redis-conn query)
-         (map (juxt #(subs % prefix-len)
-                    #(redis/llen redis-conn %)))
-         (into {}))))
-
-(defn count-queues [{:keys [redis-conn] :as config}]
+(defn count-queues [grouped-queue-counter]
   {:post [(map? %)
           (every? string? (keys %))
           (every? integer? (vals %))]}
   (merge-with +
-              (count-by-key (worker/queue-key config "*") redis-conn)
-              (count-by-key (worker/busy-queue-key config "*") redis-conn)))
+              (grouped-queue-counter :queue)
+              (grouped-queue-counter :busy-queue)))

--- a/src/nl/surf/eduhub_rio_mapper/metrics.clj
+++ b/src/nl/surf/eduhub_rio_mapper/metrics.clj
@@ -1,0 +1,25 @@
+(ns nl.surf.eduhub-rio-mapper.metrics
+  (:require [clojure.string :as str]
+            [nl.surf.eduhub-rio-mapper.redis :as redis]
+            [nl.surf.eduhub-rio-mapper.worker :as worker]))
+
+(defn render-metrics [queue-count]
+  {:pre [(every? string? (keys queue-count))
+         (every? integer? (vals queue-count))]}
+  (str/join "\n" (map (fn [[k v]] (format "active_and_queued_job_count{schac_home=\"%s\"} %s" k v))
+                      queue-count)))
+
+(defn- count-by-key [query redis-conn]
+  (let [prefix-len (dec (count query))]
+    (->> (redis/keys redis-conn query)
+         (map (juxt #(subs % prefix-len)
+                    #(redis/llen redis-conn %)))
+         (into {}))))
+
+(defn count-queues [{:keys [redis-conn] :as config}]
+  {:post [(map? %)
+          (every? string? (keys %))
+          (every? integer? (vals %))]}
+  (merge-with +
+              (count-by-key (worker/queue-key config "*") redis-conn)
+              (count-by-key (worker/busy-queue-key config "*") redis-conn)))

--- a/src/nl/surf/eduhub_rio_mapper/redis.clj
+++ b/src/nl/surf/eduhub_rio_mapper/redis.clj
@@ -30,6 +30,7 @@
 (defcmd del)
 (defcmd get)
 (defcmd keys)
+(defcmd llen)
 (defcmd lpop)
 (defcmd lpush)
 (defcmd lrange)

--- a/src/nl/surf/eduhub_rio_mapper/worker.clj
+++ b/src/nl/surf/eduhub_rio_mapper/worker.clj
@@ -77,10 +77,10 @@
     (when (not= 1 lua-result)
       (throw (ex-info "Lock lost before extend!" {:lock-name k})))))
 
-(defn- queue-key [config queue]
+(defn queue-key [config queue]
   (prefix-key config (str "queue:" queue)))
 
-(defn- busy-queue-key [config queue]
+(defn busy-queue-key [config queue]
   (prefix-key config (str "busy-queue:" queue)))
 
 (defn- add-to-queue!
@@ -94,18 +94,6 @@
    redis-conn (queue-key config (queue-fn job)) job)
   (set-status-fn job :pending)
   job)
-
-(defn- count-by-key [query redis-conn]
-  (let [prefix-len (dec (count query))]
-    (->> (redis/keys redis-conn query)
-         (map (juxt #(subs % prefix-len)
-                    #(redis/llen redis-conn %)))
-         (into {}))))
-
-(defn count-queues [{:keys [redis-conn] :as config}]
-  (merge-with +
-              (count-by-key (queue-key config "*") redis-conn)
-              (count-by-key (busy-queue-key config "*") redis-conn)))
 
 (defn enqueue!
   "Enqueue a job."

--- a/test/nl/surf/eduhub_rio_mapper/api_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/api_test.clj
@@ -135,6 +135,13 @@
   (is (= "12345678-1234-2345-3456-123456789abc"
          (-> :get (request "/status/12345678-1234-2345-3456-123456789abc") (api/routes) :token))))
 
+(deftest metrics
+  (let [app (api/wrap-metrics-getter api/routes (constantly {"foo" 1, "bar" 2}))
+        {:keys [status body]} (app (request :get "/metrics"))]
+    (is (= http-status/ok status))
+    (is (= "active_and_queued_job_count{schac_home=\"foo\"} 1\nactive_and_queued_job_count{schac_home=\"bar\"} 2"
+           body))))
+
 (deftest wrap-job-queuer
   (let [queue-atom (atom [])
         app        (api/wrap-job-enqueuer identity #(swap! queue-atom conj %))]

--- a/test/nl/surf/eduhub_rio_mapper/metrics_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/metrics_test.clj
@@ -1,0 +1,7 @@
+(ns nl.surf.eduhub-rio-mapper.metrics-test
+  (:require [clojure.test :refer :all]
+            [nl.surf.eduhub-rio-mapper.metrics :as metrics]))
+
+(deftest render-metrics
+  (is (= (metrics/render-metrics {"google" 12 "meta" 32})
+         "active_and_queued_job_count{schac_home=\"google\"} 12\nactive_and_queued_job_count{schac_home=\"meta\"} 32")))


### PR DESCRIPTION
Includes the active job, if present.
Tested with smoketest-api
