### PR TITLE
Show all schac-homes; rename metrics

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/api.clj
+++ b/src/nl/surf/eduhub_rio_mapper/api.clj
@@ -23,7 +23,7 @@
             [nl.jomco.http-status-codes :as http-status]
             [nl.jomco.ring-trace-context :refer [wrap-trace-context]]
             [nl.surf.eduhub-rio-mapper.api.authentication :as authentication]
-            [nl.surf.eduhub-rio-mapper.clients-info :refer [wrap-client-info]]
+            [nl.surf.eduhub-rio-mapper.clients-info :refer [wrap-client-info] :as clients-info]
             [nl.surf.eduhub-rio-mapper.job :as job]
             [nl.surf.eduhub-rio-mapper.logging :refer [wrap-logging with-mdc]]
             [nl.surf.eduhub-rio-mapper.metrics :as metrics]
@@ -167,7 +167,8 @@
       (wrap-callback-extractor)
       (wrap-job-enqueuer (partial worker/enqueue! config))
       (wrap-status-getter config)
-      (wrap-metrics-getter (fn [] (metrics/count-queues #(worker/queue-counts-by-key % config))))
+      (wrap-metrics-getter (fn [] (metrics/count-queues #(worker/queue-counts-by-key % config)
+                                                        (clients-info/institution-schac-homes clients))))
       (wrap-client-info clients)
       (authentication/wrap-authentication (-> (authentication/make-token-authenticator auth-config)
                                               (authentication/cache-token-authenticator {:ttl-minutes 10})))

--- a/src/nl/surf/eduhub_rio_mapper/metrics.clj
+++ b/src/nl/surf/eduhub_rio_mapper/metrics.clj
@@ -12,6 +12,7 @@
   {:post [(map? %)
           (every? string? (keys %))
           (every? integer? (vals %))]}
+  ;; For all keys in client-schac-homes, add value 0 in map if not already in map
   (reduce (fn [m k] (assoc m k (get m k 0)))
           (merge-with +
                       (grouped-queue-counter :queue)

--- a/src/nl/surf/eduhub_rio_mapper/metrics.clj
+++ b/src/nl/surf/eduhub_rio_mapper/metrics.clj
@@ -5,13 +5,15 @@
   {:pre [(map? queue-count)
          (every? string? (keys queue-count))
          (every? integer? (vals queue-count))]}
-  (str/join "\n" (map (fn [[k v]] (format "active_and_queued_job_count{schac_home=\"%s\"} %s" k v))
+  (str/join "\n" (map (fn [[k v]] (format "rio_mapper_active_and_queued_job_count{schac_home=\"%s\"} %s" k v))
                       queue-count)))
 
-(defn count-queues [grouped-queue-counter]
+(defn count-queues [grouped-queue-counter client-schac-homes]
   {:post [(map? %)
           (every? string? (keys %))
           (every? integer? (vals %))]}
-  (merge-with +
-              (grouped-queue-counter :queue)
-              (grouped-queue-counter :busy-queue)))
+  (reduce (fn [m k] (assoc m k (get m k 0)))
+          (merge-with +
+                      (grouped-queue-counter :queue)
+                      (grouped-queue-counter :busy-queue))
+          client-schac-homes))

--- a/test/nl/surf/eduhub_rio_mapper/api_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/api_test.clj
@@ -158,7 +158,7 @@
   (let [app (api/wrap-metrics-getter api/routes (constantly {"foo" 1, "bar" 2}))
         {:keys [status body]} (app (request :get "/metrics"))]
     (is (= http-status/ok status))
-    (is (= "active_and_queued_job_count{schac_home=\"foo\"} 1\nactive_and_queued_job_count{schac_home=\"bar\"} 2"
+    (is (= "rio_mapper_active_and_queued_job_count{schac_home=\"foo\"} 1\nrio_mapper_active_and_queued_job_count{schac_home=\"bar\"} 2"
            body))))
 
 (deftest wrap-job-queuer

--- a/test/nl/surf/eduhub_rio_mapper/metrics_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/metrics_test.clj
@@ -4,4 +4,4 @@
 
 (deftest render-metrics
   (is (= (metrics/render-metrics {"google" 12 "meta" 32})
-         "active_and_queued_job_count{schac_home=\"google\"} 12\nactive_and_queued_job_count{schac_home=\"meta\"} 32")))
+         "rio_mapper_active_and_queued_job_count{schac_home=\"google\"} 12\nrio_mapper_active_and_queued_job_count{schac_home=\"meta\"} 32")))


### PR DESCRIPTION
Tested while running smoketest-api - all schac-homes were included.

Regarding trello ticket with contents:

Het produceren van de metrics (active_and_queued_job_count) werkt nog niet helemaal zoals gewenst.

Op dit moment wordt er voor een bepaalde schachome alleen een metric gerenderd als de count => 1. Dat zorgt voor rare grafieken in Grafana (zie screenshot).

Beter is om voor elke schachome in de clients.json altijd een metric te renderen. De waarde daarvan is dan nul als er geen enkele job voor die instelling queued of active is.

Verder een verzoek om de metric te hernoemen naar rio_mapper_active_and_queued_job_count
