### PR TITLE
Also sort proposed cohorts

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/processing.clj
+++ b/src/nl/surf/eduhub_rio_mapper/processing.clj
@@ -188,7 +188,10 @@
 (defn- course-program-dry-run-handler [ooapi-entity {::ooapi/keys [id] :keys [institution-oin] :as request} {:keys [rio-config ooapi-loader]}]
   (let [rio-obj     (rio.loader/find-aangebodenopleiding id institution-oin rio-config)
         rio-summary (dry-run/summarize-aangebodenopleiding-xml rio-obj)
-        offering-summary (mapv dry-run/summarize-offering (ooapi.loader/load-offerings ooapi-loader request))
+        offering-summary (->> (ooapi.loader/load-offerings ooapi-loader request)
+                              (map dry-run/summarize-offering)
+                              (sort-by :cohortcode)
+                              vec)
         ooapi-summary (dry-run/summarize-course-program (assoc ooapi-entity :offerings offering-summary))
         rio-code (when rio-obj (xml-utils/find-content-in-xmlseq (xml-seq rio-obj) :aangebodenOpleidingCode))
         diff   (dry-run/generate-diff-ooapi-rio :rio-summary rio-summary :ooapi-summary ooapi-summary)


### PR DESCRIPTION
By mistake, only cohorten were sorted, and offerings were assumed to be sorted already.