### PR TITLE
Validate callback url

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/api.clj
+++ b/src/nl/surf/eduhub_rio_mapper/api.clj
@@ -18,6 +18,7 @@
 
 (ns nl.surf.eduhub-rio-mapper.api
   (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]
             [compojure.core :refer [GET POST]]
             [compojure.route :as route]
             [nl.jomco.http-status-codes :as http-status]
@@ -53,7 +54,7 @@
 (defn- valid-url? [url]
   (try
     (URL. url)
-    true
+    (str/starts-with? url "http")                           ; Reject non-http protocols like file://
     (catch MalformedURLException _
       false)))
 

--- a/test/nl/surf/eduhub_rio_mapper/api_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/api_test.clj
@@ -21,6 +21,7 @@
             [nl.jomco.http-status-codes :as http-status]
             [nl.surf.eduhub-rio-mapper.api :as api]
             [nl.surf.eduhub-rio-mapper.cli :as cli]
+            [nl.surf.eduhub-rio-mapper.job :as job]
             [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
             [nl.surf.eduhub-rio-mapper.rio :as rio]
             [nl.surf.eduhub-rio-mapper.status :as status]
@@ -182,6 +183,20 @@
       (is (= (-> @queue-atom first :token)
              (-> res :body :token))
           "job token same as returned token"))))
+
+(deftest wrap-callback-extractor
+  (let [app        (api/wrap-callback-extractor identity)]
+
+    (is (= {} (app {}))
+        "no callback, do nothing")
+
+    (let [res (app {:job {} :headers {"x-callback" "dummy"}})]
+      (is (= 400 (:status res))
+          "illegal url"))
+
+    (let [res (app {:job {} :headers {"x-callback" "https://surf.nl/"}})]
+      (is (-> res :job ::job/callback-url)
+          "valid url"))))
 
 (deftest ^:redis wrap-status-getter
   (let [config      {:redis-conn       {:pool {} :spec {:uri (or (System/getenv "REDIS_URI") "redis://localhost")}}


### PR DESCRIPTION
As per the following trello ticket:

Een van onze instellingen liep vast omdat ze een (bleek later) een ongeldige URL ingevoerd hadden bij de X-Callback header. Dit leidt tot een exceptie die we alleen in de logs terugzien, bijv:
java.net.MalformedURLException: no protocol: null/open-onderwijs/5.0/rio/callback/83332232-6b81-4a65-8ccb-a9c0ff469951
Bij requests die een job aanmaken waarbij de X-Callback header aanwezig is, graag controleren of het “well-formed” url is. Zo niet, dan responden met een 400 (Bad Request) in de body van de respons als plaintext een tekstje met uitleg “Malformed callback url”. De job ook niet aanmaken.
