### PR TITLE
Validate registration status of offerings

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/ooapi/offerings.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/offerings.clj
@@ -42,9 +42,15 @@
                   (= "rio" (:consumerKey %)))
             (:consumers x))))
 
+(defn has-registration-status? [x]
+  (some #(and (#{"open" "closed"} (:registrationStatus %))
+              (= "rio" (:consumerKey %)))
+        (:consumers x)))
+
 (s/def ::Offering
   (s/and
     has-mode-of-delivery?
+    has-registration-status?
     (s/keys :req-un [::Offering/offeringId
                      ::Offering/endDate
                      ::Offering/startDate

--- a/test/nl/surf/eduhub_rio_mapper/ooapi/offerings_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/ooapi/offerings_test.clj
@@ -29,17 +29,30 @@
 
 (def program-offering-demo04 (load-json "fixtures/ooapi/program-demo04-offerings.json"))
 
-(deftest validate-fixtures-explain-course-offerings
-  (let [problems (get (s/explain-data ::offr/OfferingsRequest course-offerings)
-                      :clojure.spec.alpha/problems)]
-    (is (nil? problems))))
+(deftest validate-fixtures
+  (testing "course offerings"
+    (let [problems (get (s/explain-data ::offr/OfferingsRequest course-offerings)
+                        :clojure.spec.alpha/problems)]
+      (is (nil? problems))))
 
-(deftest validate-fixtures-explain-program-offerings
-  (let [problems (get (s/explain-data ::offr/OfferingsRequest program-offerings)
-                      :clojure.spec.alpha/problems)]
-    (is (nil? problems))))
+  (testing "no registration status"
+    (let [offerings (update-in course-offerings [:items 0 :consumers 0] dissoc :registrationStatus)
+          problems (get (s/explain-data ::offr/OfferingsRequest offerings)
+                        :clojure.spec.alpha/problems)]
+      (is (some? problems))))
 
-(deftest validate-fixtures-explain-program-demo-offerings
-  (let [problems (get (s/explain-data ::offr/OfferingsRequest program-offering-demo04)
-                      :clojure.spec.alpha/problems)]
-    (is (nil? problems))))
+  (testing "wrong registration status"
+    (let [offerings (update-in course-offerings [:items 0 :consumers 0] assoc :registrationStatus "ajar")
+          problems (get (s/explain-data ::offr/OfferingsRequest offerings)
+                        :clojure.spec.alpha/problems)]
+      (is (some? problems))))
+
+  (testing "explain-program-offerings"
+    (let [problems (get (s/explain-data ::offr/OfferingsRequest program-offerings)
+                        :clojure.spec.alpha/problems)]
+      (is (nil? problems))))
+
+  (testing "explain-program-demo-offerings"
+    (let [problems (get (s/explain-data ::offr/OfferingsRequest program-offering-demo04)
+                        :clojure.spec.alpha/problems)]
+      (is (nil? problems)))))


### PR DESCRIPTION
> Lijkt erop dat we niet valideren of een offering een geldig consumer > registrationStatus attribuut heeft.

See https://trello.com/c/6OPeOOn5/228-aanscherpen-validatie-offerings
