### PR TITLE
Core functionality for serving OOAPI fixtures

### DIFF
--- a/fixtures/deps.edn
+++ b/fixtures/deps.edn
@@ -1,0 +1,16 @@
+{:paths ["src" "resources"]
+ :deps
+ {org.clojure/tools.cli          {:mvn/version "1.0.219"}
+  org.clojure/data.json          {:mvn/version "2.4.0"}
+  ring/ring-core                 {:mvn/version "1.10.0"}
+  org.clojure/tools.logging      {:mvn/version "1.2.4"}
+  ch.qos.logback/logback-core    {:mvn/version "1.3.5"}
+  org.slf4j/slf4j-api            {:mvn/version "2.0.4"}
+  compojure                      {:mvn/version "1.7.0"}
+  info.sunng/ring-jetty9-adapter {:mvn/version "0.30.1"}}
+
+ :aliases {:test      {:extra-deps {lambdaisland/kaocha            {:mvn/version "RELEASE"}
+                                    ch.qos.logback/logback-classic {:mvn/version "1.3.5"}}
+                       :main-opts  ["-m" "kaocha.runner"]}
+           :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}
+                       :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/fixtures/resources/entities/courses/demo-course.json
+++ b/fixtures/resources/entities/courses/demo-course.json
@@ -1,0 +1,179 @@
+{
+  "otherCodes": [
+    {
+      "codeType": "identifier",
+      "code": "9194814e-9ea0-1b52-de9a-0b7b9a479263"
+    }
+  ],
+  "coordinators": [
+    "173433fa-e29a-4686-8183-78591d45a25e"
+  ],
+  "level": "master",
+  "resources": [
+    "Further, lecturers will put their presentations on MyPortal. The literature will be handed out prior to and during the course. PowerPoint presentations."
+  ],
+  "educationSpecification": "38eb3cb9-9a4c-72f7-661f-7e544f4ceba5",
+  "organization": "7dc96d2e-b3af-9a63-5524-dc60eb818fd0",
+  "modeOfDelivery": [
+    "online",
+    "hybrid"
+  ],
+  "validFrom": "1997-10-24",
+  "addresses": [
+    {
+      "countryCode": "NL",
+      "city": "Vriescheloo",
+      "geoLocation": {
+        "longitude": 117,
+        "latitude": 2
+      },
+      "addressType": "teaching",
+      "streetNumber": 194,
+      "postalCode": "4108VO",
+      "street": "Borgesiuslaan",
+      "additional": ""
+    }
+  ],
+  "duration": "P1DT30H4S",
+  "abbreviation": "MTBIDVE",
+  "validTo": "2006-08-06",
+  "enrollment": [
+    {
+      "language": "en-GB",
+      "value": "EN TRANSLATION: . . ."
+    },
+    {
+      "language": "nl-NL",
+      "value": "NL VERTALING: . . ."
+    }
+  ],
+  "teachingLanguage": "nld",
+  "assessment": [
+    {
+      "language": "en-GB",
+      "value": "EN TRANSLATION: All practical exercises have to be able to complete the course should be 5.50 minimum. A geometric mean is taken, which means students must have passed all three course elements exceed 5.50, the final grade. The final mark for each component."
+    },
+    {
+      "language": "nl-NL",
+      "value": "NL VERTALING: All practical exercises have to be able to complete the course should be 5.50 minimum. A geometric mean is taken, which means students must have passed all three course elements exceed 5.50, the final grade. The final mark for each component."
+    }
+  ],
+  "firstStartDate": "2020-06-13",
+  "learningOutcomes": [
+    [
+      {
+        "language": "en-GB",
+        "value": "EN TRANSLATION: nieuwe inzichten over het opdoen van kennis in een complexe wereld"
+      },
+      {
+        "language": "nl-NL",
+        "value": "NL VERTALING: nieuwe inzichten over het opdoen van kennis in een complexe wereld"
+      }
+    ],
+    [
+      {
+        "language": "en-GB",
+        "value": "EN TRANSLATION: nieuw talent op het gebied van programmeren"
+      },
+      {
+        "language": "nl-NL",
+        "value": "NL VERTALING: nieuw talent op het gebied van programmeren"
+      }
+    ],
+    [
+      {
+        "language": "en-GB",
+        "value": "EN TRANSLATION: inzicht in de bijzondere eigenschappen van materialen"
+      },
+      {
+        "language": "nl-NL",
+        "value": "NL VERTALING: inzicht in de bijzondere eigenschappen van materialen"
+      }
+    ],
+    [
+      {
+        "language": "en-GB",
+        "value": "EN TRANSLATION: kennis van de meestgebruikte ingrediënten in dit vak"
+      },
+      {
+        "language": "nl-NL",
+        "value": "NL VERTALING: kennis van de meestgebruikte ingrediënten in dit vak"
+      }
+    ]
+  ],
+  "qualificationRequirements": [
+    {
+      "language": "en-GB",
+      "value": "EN TRANSLATION: You must meet the following requirements - Enrolled for a degree programme of faculty Faculty of Humanities - Obtained at least 45 ECTS for the 1-sample and 2-sample situations, in case of doubt, contact the course before the registration deadlines (one month before the course will be required and therefore the course objectives and whether your expectations will fit with the applicable contact person.YWU-70318 BSc Internship International Land and Water Management. . ETE-22806 Principles of Earth and Ecosystem Science or SOC-36306 Biogeochemical Cycles and Climate Change Economics and Governance. You must meet the following degree programmes - History - History - Language Acquisition Arabic 1 (IA1V13001) - Collection 2 - At least 1 of the BSc programma in Nutrition and HNH-26806 Introduction to Global Change, ENP-34306 Environmental Policy: Analysis and Prevention of Health Risks in the Social Sciences; YSS-10906 Analysis of a standard comparable to that encountered in normal scientific vocabulary and phrasing, and scientific units, species names, the names of chemicals etc should all be written in this course cannot be followed simultaneously in block, either in periods 1, 2 and SLM-20306 Land and Water Management and MarketingMCB-20806 Principles of Entrepreneurship or other MSc study programme of faculty Faculty of Humanities - Obtained at least 45 ECTS for the category Bachelor Introductory."
+    },
+    {
+      "language": "nl-NL",
+      "value": "NL VERTALING: You must meet the following requirements - Enrolled for a degree programme of faculty Faculty of Humanities - Obtained at least 45 ECTS for the 1-sample and 2-sample situations, in case of doubt, contact the course before the registration deadlines (one month before the course will be required and therefore the course objectives and whether your expectations will fit with the applicable contact person.YWU-70318 BSc Internship International Land and Water Management. . ETE-22806 Principles of Earth and Ecosystem Science or SOC-36306 Biogeochemical Cycles and Climate Change Economics and Governance. You must meet the following degree programmes - History - History - Language Acquisition Arabic 1 (IA1V13001) - Collection 2 - At least 1 of the BSc programma in Nutrition and HNH-26806 Introduction to Global Change, ENP-34306 Environmental Policy: Analysis and Prevention of Health Risks in the Social Sciences; YSS-10906 Analysis of a standard comparable to that encountered in normal scientific vocabulary and phrasing, and scientific units, species names, the names of chemicals etc should all be written in this course cannot be followed simultaneously in block, either in periods 1, 2 and SLM-20306 Land and Water Management and MarketingMCB-20806 Principles of Entrepreneurship or other MSc study programme of faculty Faculty of Humanities - Obtained at least 45 ECTS for the category Bachelor Introductory."
+    }
+  ],
+  "name": [
+    {
+      "language": "en-GB",
+      "value": "EN TRANSLATION: MFA Theatervormgeving/Beeldregie in de vorige eeuw"
+    },
+    {
+      "language": "nl-NL",
+      "value": "NL VERTALING: MFA Theatervormgeving/Beeldregie in de vorige eeuw"
+    }
+  ],
+  "admissionRequirements": [
+    {
+      "language": "en-GB",
+      "value": "EN TRANSLATION: An absolute minimum requirement is enacted through the courses below must have a basic understanding of (micro-) economic theory would be useful, but not formally required. ESA-22806 Environmental Systems Analysis: Methods and Applications or ESA-23306 Introduction to Soil Chemical, Physical and Chemical Processes for Water Use from Multiple Sources; or WSG-33806 Integrated Water Management must be combined with PCC-21802 Introductory Thermodynamics. Successfully passing e.g."
+    },
+    {
+      "language": "nl-NL",
+      "value": "NL VERTALING: An absolute minimum requirement is enacted through the courses below must have a basic understanding of (micro-) economic theory would be useful, but not formally required. ESA-22806 Environmental Systems Analysis: Methods and Applications or ESA-23306 Introduction to Soil Chemical, Physical and Chemical Processes for Water Use from Multiple Sources; or WSG-33806 Integrated Water Management must be combined with PCC-21802 Introductory Thermodynamics. Successfully passing e.g."
+    }
+  ],
+  "primaryCode": {
+    "codeType": "identifier",
+    "code": "9194814e-9ea0-1b52-de9a-0b7b9a479263"
+  },
+  "link": "https://hogeschool-van-vriescheloo.nl/courses/9194814e-9ea0-1b52-de9a-0b7b9a479263",
+  "description": [
+    {
+      "language": "en-GB",
+      "value": "EN TRANSLATION: The analysis of organic matter, nitrogen and phosphorus removal in activated sludge processes and process perspective and discuss the course knowledge about their career in plant biotechnology; - there will be linked to metabolism, how metabolism can be investigated by using methods and interpreting models. This requires a blend of micro- and macroeconomic theory, institutional material, and real-world applications. Each group gives an overview of the specialization European Master in Food Studies specialisation of the course focuses on design aspects of water are used to convey a basic foundation in these techniques, with emphasis on the site and context requires different solutions."
+    },
+    {
+      "language": "nl-NL",
+      "value": "NL VERTALING: The analysis of organic matter, nitrogen and phosphorus removal in activated sludge processes and process perspective and discuss the course knowledge about their career in plant biotechnology; - there will be linked to metabolism, how metabolism can be investigated by using methods and interpreting models. This requires a blend of micro- and macroeconomic theory, institutional material, and real-world applications. Each group gives an overview of the specialization European Master in Food Studies specialisation of the course focuses on design aspects of water are used to convey a basic foundation in these techniques, with emphasis on the site and context requires different solutions."
+    }
+  ],
+  "fieldsOfStudy": "0416",
+  "courseId": "demo-course",
+  "consumers": [
+    {
+      "alliances": [
+        {
+          "name": "lde",
+          "enrollmentForOwnStudents": "broker",
+          "type": "broadening",
+          "visibleForOwnStudents": true,
+          "selection": false,
+          "theme": "Engineering, Manufacturing and Construction"
+        }
+      ],
+      "consumerKey": "eduxchange"
+    },
+    {
+      "consumerKey": "rio",
+      "educationOffererCode": "122A112",
+      "educationLocationCode": "123X122",
+      "consentParticipationSTAP": "permission_not_granted"
+    }
+  ],
+  "studyLoad": {
+    "value": 177,
+    "studyLoadUnit": "ects"
+  },
+  "programs": [
+    "a-program"
+  ]
+}

--- a/fixtures/resources/entities/programs/a-program.json
+++ b/fixtures/resources/entities/programs/a-program.json
@@ -1,0 +1,169 @@
+{
+  "fieldsOfStudy": "0311",
+  "teachingLanguage": "eng",
+  "studyLoad": {
+    "value": 167,
+    "studyLoadUnit": "ects"
+  },
+  "organization": "7dc96d2e-b3af-9a63-5524-dc60eb818fd0",
+  "level": "undivided",
+  "educationSpecification": "b3e7b801-a5a9-d99b-9d20-3fb1b1211b0e",
+  "name": [
+    {
+      "language": "en-GB",
+      "value": "EN TRANSLATION: Duurzaam Bodembeheer"
+    },
+    {
+      "language": "nl-NL",
+      "value": "NL VERTALING: Duurzaam Bodembeheer"
+    }
+  ],
+  "sector": "secondary vocational education",
+  "validFrom": "1999-03-31",
+  "addresses": [
+    {
+      "countryCode": "NL",
+      "city": "Vriescheloo",
+      "geoLocation": {
+        "longitude": 117,
+        "latitude": 2
+      },
+      "addressType": "teaching",
+      "streetNumber": 194,
+      "postalCode": "4108VO",
+      "street": "Borgesiuslaan",
+      "additional": ""
+    }
+  ],
+  "programType": "program",
+  "primaryCode": {
+    "codeType": "crohoCreboCode",
+    "code": "80070"
+  },
+  "modeOfDelivery": [
+    "situated",
+    "on campus",
+    "distance-learning"
+  ],
+  "duration": "P1DT30H4S",
+  "qualificationAwarded": "AD",
+  "link": "https://hogeschool-van-vriescheloo.nl/programs/10bb1de4-a7f8-8519-a827-cb68805c68e8",
+  "coordinators": [
+    "41181a76-fc85-2825-0730-53536f6cc629"
+  ],
+  "otherCodes": [
+    {
+      "codeType": "crohoCreboCode",
+      "code": "80070"
+    }
+  ],
+  "validTo": "2006-05-26",
+  "modeOfStudy": "full-time",
+  "assessment": [
+    {
+      "language": "en-GB",
+      "value": "EN TRANSLATION: Written examination (50%) and the lab grade should be successfully completed and handed in. For both a minimum grade 5.0 out of 90 points. - computer simulations (20%); - outcomes of the future development of their work."
+    },
+    {
+      "language": "nl-NL",
+      "value": "NL VERTALING: Written examination (50%) and the lab grade should be successfully completed and handed in. For both a minimum grade 5.0 out of 90 points. - computer simulations (20%); - outcomes of the future development of their work."
+    }
+  ],
+  "description": [
+    {
+      "language": "en-GB",
+      "value": "EN TRANSLATION: Many technological developments will be given by the introduction of the field of land use and integrate landscape developments on different levels of scale (international, national as well as electron spin-nuclear spin interactions. In groups the students will have to integrate natural science to global change. From there, a journey is undertaken in search of the course, the project for their cables and pipes."
+    },
+    {
+      "language": "nl-NL",
+      "value": "NL VERTALING: Many technological developments will be given by the introduction of the field of land use and integrate landscape developments on different levels of scale (international, national as well as electron spin-nuclear spin interactions. In groups the students will have to integrate natural science to global change. From there, a journey is undertaken in search of the course, the project for their cables and pipes."
+    }
+  ],
+  "levelOfQualification": "4+",
+  "consumers": [
+    {
+      "alliances": [
+        {
+          "name": "ewuu",
+          "enrollmentForOwnStudents": "broker",
+          "type": "deepening",
+          "visibleForOwnStudents": false,
+          "selection": true,
+          "theme": "12"
+        }
+      ],
+      "consumerKey": "eduxchange"
+    },
+    {
+      "educationOffererCode": "122A112",
+      "acceleratedRoute": "no_accelerated_route",
+      "consentParticipationSTAP": "permission_not_granted",
+      "deficiency": "no_deficiencies",
+      "studyChoiceCheck": "study_choice_check_mandatory",
+      "consumerKey": "rio",
+      "requirementsActivities": "no_requirements",
+      "propaedeuticPhase": "no_propaedeutic_phase",
+      "educationLocationCode": "123X122"
+    }
+  ],
+  "programId": "a-program",
+  "firstStartDate": "2022-03-14",
+  "resources": [
+    ". Case materials depending on the Brightspace site BSc thesis Biosystems Engineering. Elsevier Science Publishers, Amsterdam, 2nd ed.",
+    "A manual and texts to study will become available in Learning environment@WUR. 6th ed.Berg, J.M.; Tymoczko, J.L.; Stryer, L.; Gatto, G.J. Furthermore, before each lecture a PowerPoint presentation on the first day of the 27th Conference on Education and Research in Computer Aided Architectural Design in Social Research.",
+    ". To be announced. Scheffer (2009) Critical Transitions in Nature and Society."
+  ],
+  "qualificationRequirements": [
+    {
+      "language": "en-GB",
+      "value": "EN TRANSLATION: All BSc-1 and BSc-2 courses of the final competences for Dutch VWO Wiskunde A (Mathematics A) or comparable knowledge.Plus one of the courses below in parallel to Thesis Path:YRM-20806 Research Design & Research Methods; CPT-21304 Introduction to Communication and Innovation Studies (CPT-23804). . TOX-30306 Food Toxicology; FHM-32306 Advanced Food Physics or equivalents."
+    },
+    {
+      "language": "nl-NL",
+      "value": "NL VERTALING: All BSc-1 and BSc-2 courses of the final competences for Dutch VWO Wiskunde A (Mathematics A) or comparable knowledge.Plus one of the courses below in parallel to Thesis Path:YRM-20806 Research Design & Research Methods; CPT-21304 Introduction to Communication and Innovation Studies (CPT-23804). . TOX-30306 Food Toxicology; FHM-32306 Advanced Food Physics or equivalents."
+    }
+  ],
+  "abbreviation": "DB",
+  "learningOutcomes": [
+    [
+      {
+        "language": "en-GB",
+        "value": "EN TRANSLATION: nieuwe inzichten over het opdoen van kennis in een complexe wereld"
+      },
+      {
+        "language": "nl-NL",
+        "value": "NL VERTALING: nieuwe inzichten over het opdoen van kennis in een complexe wereld"
+      }
+    ],
+    [
+      {
+        "language": "en-GB",
+        "value": "EN TRANSLATION: nieuw talent op het gebied van programmeren"
+      },
+      {
+        "language": "nl-NL",
+        "value": "NL VERTALING: nieuw talent op het gebied van programmeren"
+      }
+    ]
+  ],
+  "admissionRequirements": [
+    {
+      "language": "en-GB",
+      "value": "EN TRANSLATION: . To be determined by thesis professor. You must meet the following requirements - Enrolled for a degree programme of faculty Graduate School of Teaching."
+    },
+    {
+      "language": "nl-NL",
+      "value": "NL VERTALING: . To be determined by thesis professor. You must meet the following requirements - Enrolled for a degree programme of faculty Graduate School of Teaching."
+    }
+  ],
+  "enrollment": [
+    {
+      "language": "en-GB",
+      "value": "EN TRANSLATION: Osiris. . ."
+    },
+    {
+      "language": "nl-NL",
+      "value": "NL VERTALING: Osiris. . ."
+    }
+  ]
+}

--- a/fixtures/src/nl/surf/rio_mapper/e2e/fixtures/entities.clj
+++ b/fixtures/src/nl/surf/rio_mapper/e2e/fixtures/entities.clj
@@ -1,0 +1,74 @@
+(ns nl.surf.rio-mapper.e2e.fixtures.entities
+  (:require [clojure.java.io :as io]
+            [clojure.data.json :as json]
+            [nl.surf.rio-mapper.e2e.fixtures.ids :as ids]
+            [clojure.walk :as walk])
+  (:import java.io.File java.util.regex.Pattern))
+
+
+(defn- find-files
+  ([^String path ^File f ^Pattern p]
+   (if (.isDirectory f)
+     (mapcat #(find-files (str path "/" (.getName %)) % p) (.listFiles f))
+     (when (re-matches p (.getName f))
+       [path])))
+  ([^File f ^Pattern p]
+   (find-files (.getName f) f p)))
+
+(defn- entity-resources
+  []
+  (let [dir (-> "entities"
+                io/resource
+                io/file)]
+    (when-not (.isDirectory dir)
+      (throw (IllegalStateException. (str "entities is not a directory -- are you running in a jar?"))))
+    (find-files dir #".*\.json$")))
+
+(defn- load-entity
+  [type name]
+  (-> (str "entities/" type "/" name ".json")
+      io/resource
+      (io/reader :encoding "UTF-8")
+      json/read-json))
+
+(defn- load-entities
+  []
+  (reduce
+   (fn [entities path]
+     (when-let [[_ type name] (re-matches #"entities\/([^/]+)\/([^.]+)\.json" path)]
+       (assoc-in entities [(keyword type) name] (load-entity type name))))
+   {}
+   (entity-resources)))
+
+(defn fixtures
+  []
+  (let [entities (load-entities)
+        names    (mapcat keys (vals entities))
+        nameset  (ids/nameset names)]
+    {:entities entities
+     :nameset nameset}))
+
+(defn- set-entity-ids
+  [entity nameset session]
+  (cond
+    (sequential? entity)
+    (mapv #(set-entity-ids % nameset session) entity)
+
+    (map? entity)
+    (reduce-kv (fn [m k v]
+                 (assoc m k (set-entity-ids v nameset session)))
+               {}
+               entity)
+
+    (and (string? entity)
+         (ids/name? nameset entity))
+    (ids/name->uuid nameset session entity)
+
+    :else
+    entity))
+
+(defn get-entity
+  [{:keys [entities nameset] :as _fixtures} type uuid]
+  (let [session (ids/uuid->session uuid)]
+    (-> (get-in entities [type (ids/uuid->name nameset uuid)])
+        (set-entity-ids nameset session))))

--- a/fixtures/src/nl/surf/rio_mapper/e2e/fixtures/ids.clj
+++ b/fixtures/src/nl/surf/rio_mapper/e2e/fixtures/ids.clj
@@ -1,0 +1,60 @@
+(ns nl.surf.rio-mapper.e2e.fixtures.ids
+  "Map names to UUIDs and vice versa."
+  (:import java.util.UUID))
+
+;;  "a3b07526-a18f-10e8-937b-3404198139d8"
+;;    tlow    tmid vthi vseq      node
+;;
+;;   4 bytes  2byt 2byt 2byt   6 bytes
+;;
+;;   0         1         2       x 3
+;;   012345678901234567890123456789012345
+
+
+(defn nameset
+  [names]
+  (let [names (vec (sort names))]
+    {:names   names
+     :indexes (into {}
+                    (map-indexed (fn [i n] [n i]))
+                    names)}))
+
+(defn name?
+  [{:keys [indexes] :as _nameset} n]
+  (contains? indexes n))
+
+(defn- name->index
+  [nameset n]
+  (or (get-in nameset [:indexes n])
+      (throw (ex-info (str "Name not found: " n)
+                      {:name n}))))
+
+(defn- name->mac
+  [nameset n]
+  ;; convert n to index,
+  ;; then index to mac address (12 digit hex string)
+  (format "%012x" (name->index nameset n)))
+
+(defn name->uuid
+  [nameset session n]
+  (UUID/fromString (str session (name->mac nameset n))))
+
+(defn- uuid->index
+  [u]
+  (Long/parseLong (subs (str u) 24) 16))
+
+(defn uuid->name
+  [nameset u]
+  (get-in nameset [:names (uuid->index u)]))
+
+(defn mk-session
+  "Create a new random session identifier"
+  []
+  (let [rnd (str (UUID/randomUUID))]
+    (str (subs rnd 0 14)
+         "1" ;; force to version 1
+         (subs rnd 15 24))))
+
+(defn uuid->session
+  [u]
+  (subs (str u) 0 24))

--- a/fixtures/src/nl/surf/rio_mapper/e2e/fixtures/server.clj
+++ b/fixtures/src/nl/surf/rio_mapper/e2e/fixtures/server.clj
@@ -1,0 +1,29 @@
+(ns nl.surf.rio-mapper.e2e.fixtures.server
+  (:require [clojure.data.json :as json]
+            [clojure.tools.logging :as log]
+            [compojure.core :refer [GET routes]]
+            [compojure.route :as route]
+            [nl.surf.rio-mapper.e2e.fixtures.entities :as entities]
+            [ring.adapter.jetty9 :refer [run-jetty]]))
+
+(defn mk-app
+  [fixtures]
+  (-> (routes
+       (GET "/:type/:uuid" [type uuid]
+         (log/info "GET" type uuid)
+         (when-let [entity (entities/get-entity fixtures (keyword type) uuid)]
+           {:status       200
+            :content-type "application/json; charset=utf-8"
+            :body         (json/write-str entity)}))
+
+       (route/not-found "Entity not found"))))
+
+(defn start-server
+  [port]
+  (run-jetty (mk-app (entities/fixtures))
+             {:join? false
+              :port port}))
+
+(defn stop-server
+  [s]
+  (.stop s))

--- a/fixtures/src/nl/surf/rio_mapper/e2e/fixtures/session.clj
+++ b/fixtures/src/nl/surf/rio_mapper/e2e/fixtures/session.clj
@@ -1,0 +1,31 @@
+(ns nl.surf.rio-mapper.e2e.fixtures.session
+  "Helper bindings for converting fixture entity names to uuids.
+  These are intented to be used in tests.
+
+  Use `(use-fixtures :once with-name-session)` at the top of your
+  tests, then, in your tests, call `(name->id NAME)` to get a uuid for
+  the entity with that name."
+  (:require [nl.surf.rio-mapper.e2e.fixtures.entities :as entities]
+            [nl.surf.rio-mapper.e2e.fixtures.ids :as ids]))
+
+(def ^:dynamic
+  *config*
+  nil)
+
+(defmacro with-name-session
+  [& body]
+  `(binding [*config* {:session (ids/mk-session)
+                       :nameset (:nameset (entities/fixtures))}]
+     ~@body))
+
+(defn name->uuid
+  [n]
+  (when-not *config*
+    (throw (IllegalStateException. "Can't call `session/name->uuid` outside `with-name-session`.")))
+  (ids/name->uuid (:nameset *config*) (:session *config*) n))
+
+(defn uuid->name
+  [u]
+  (when-not *config*
+    (throw (IllegalStateException. "Can't call `session/uuid->name` outside `with-name-session`.")))
+  (ids/uuid->name (:nameset *config*) u))

--- a/fixtures/test/nl/surf/rio_mapper/e2e/fixtures/entities_test.clj
+++ b/fixtures/test/nl/surf/rio_mapper/e2e/fixtures/entities_test.clj
@@ -1,0 +1,26 @@
+(ns nl.surf.rio-mapper.e2e.fixtures.entities-test
+  (:require [nl.surf.rio-mapper.e2e.fixtures.entities :as sut]
+            [nl.surf.rio-mapper.e2e.fixtures.ids :as ids]
+            [clojure.test :refer [deftest is]])
+  (:import java.util.UUID))
+
+(def entity-fixtures
+  (sut/fixtures))
+
+(def nameset (:nameset entity-fixtures))
+
+(def session (ids/mk-session))
+
+(def course-id (ids/name->uuid nameset session "demo-course"))
+
+(def program-id (ids/name->uuid nameset session "a-program"))
+
+(deftest test-entities
+  (let [course (sut/get-entity entity-fixtures :courses course-id)]
+    (is course)
+    (is (not= "demo-course" (:courseId course)))
+    (let [programs (:programs course)]
+      (is (not= ["a-program"] programs)
+          "uuids generated for entity names")
+      (is (= ["a-program"] (map #(ids/uuid->name nameset %) (:programs course)))))
+    (is (sut/get-entity entity-fixtures :programs program-id))))

--- a/fixtures/test/nl/surf/rio_mapper/e2e/fixtures/ids_test.clj
+++ b/fixtures/test/nl/surf/rio_mapper/e2e/fixtures/ids_test.clj
@@ -1,0 +1,16 @@
+(ns nl.surf.rio-mapper.e2e.fixtures.ids-test
+  (:require [nl.surf.rio-mapper.e2e.fixtures.ids :as sut]
+            [clojure.test :refer [deftest is]])
+  (:import java.util.UUID))
+
+(def names
+  ["foo" "bar" "baz"])
+
+(deftest roundtrip
+  (let [nameset (sut/nameset names)
+        session (sut/mk-session)]
+    (doseq [name names]
+      (let [uuid (sut/name->uuid nameset session name)]
+        (is (uuid? uuid))
+        (is (= name (sut/uuid->name nameset uuid)))
+        (is (= session (sut/uuid->session uuid)))))))


### PR DESCRIPTION
Implemented as a standalone project under `/fixtures`. Can be merged with other test code if necessary.

resources/entities contains json files of entities with paths similar to OOAPI paths, but with readable names instead of uuids.

Any references in json to other existing entities should also use names, including the id of the entity itself, so:

In courses/demo-course.json:
```
{
  ...
  "courseId": "demo-course"
  "programs: ["a-program"]
}
```

The OOAPI server can be started and stopped using the `nl.surf.rio-mapper.e2e.fixtures.server` namespace.

In tests, fixture names can be mapped to uuids using the `nl.surf.rio-mapper.e2e.fixtures.session` namespace.