### PR TITLE
Turn off logging about logging

### DIFF
--- a/dev/logback-test.xml
+++ b/dev/logback-test.xml
@@ -47,6 +47,7 @@
             </layout>
         </encoder>
     </appender>
+    <logger name="ch.qos.logback" level="WARN" />
     <logger name="org.eclipse.jetty" level="INFO" />
     <logger name="org.eclipse.jetty.server" level="WARN" />
     <logger name="org.eclipse.jetty.util.log" level="WARN" />


### PR DESCRIPTION
`lein mapper serve-api` was showing a lot of logback garbage.