### PR TITLE
Fix deps failure

### DIFF
--- a/.nvd-suppressions.xml
+++ b/.nvd-suppressions.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <!-- See also: https://jeremylong.github.io/DependencyCheck/general/suppression.html -->
+  <suppress>
+    <notes>Using clojure higher than 1.9.0 and not earlier as implied by some dependencies.</notes>
+    <cve>CVE-2017-20189</cve>
+  </suppress>
 </suppressions>

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [nl.jomco/envopts "0.0.4"]
 
                  ;; API
-                 [compojure "1.7.0"]
+                 [compojure "1.7.1"]
                  [ring/ring-jetty-adapter "1.11.0"]
                  [ring/ring-core "1.11.0"]
                  [ring/ring-defaults "0.4.0"]


### PR DESCRIPTION
Our dependencies seem to import older versions of clojure making NVD trip over clojure pre 1.9.0 which has a vulnerability but we're not using an old version of clojure.