### PR TITLE
Added /health endpoint

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/app_server.clj
+++ b/src/nl/surf/eduhub_rio_mapper/app_server.clj
@@ -1,0 +1,15 @@
+(ns nl.surf.eduhub-rio-mapper.app-server
+  (:require [ring.adapter.jetty :as jetty])
+  (:import [org.eclipse.jetty.server HttpConnectionFactory]))
+
+(defn run-jetty [app host port]
+  (jetty/run-jetty app
+                   {:host         host
+                    :port         port
+                    :join?        true
+                    ;; Configure Jetty to not send server version
+                    :configurator (fn [jetty]
+                                    (doseq [connector (.getConnectors jetty)]
+                                      (doseq [connFact (.getConnectionFactories connector)]
+                                        (when (instance? HttpConnectionFactory connFact)
+                                          (.setSendServerVersion (.getHttpConfiguration connFact) false)))))}))

--- a/src/nl/surf/eduhub_rio_mapper/health.clj
+++ b/src/nl/surf/eduhub_rio_mapper/health.clj
@@ -1,0 +1,10 @@
+(ns nl.surf.eduhub-rio-mapper.health
+  (:require [nl.surf.eduhub-rio-mapper.worker :as worker]))
+
+;; Should always return true if redis is up
+(defn redis-up? [config]
+  (try
+    (let [occ (worker/occupied-queues config)]
+      (vector? occ))
+    (catch Exception _ex
+      false)))

--- a/src/nl/surf/eduhub_rio_mapper/health.clj
+++ b/src/nl/surf/eduhub_rio_mapper/health.clj
@@ -1,10 +1,22 @@
 (ns nl.surf.eduhub-rio-mapper.health
-  (:require [nl.surf.eduhub-rio-mapper.worker :as worker]))
+  (:require [nl.jomco.http-status-codes :as http-status]
+            [nl.surf.eduhub-rio-mapper.worker :as worker]))
 
 ;; Should always return true if redis is up
 (defn redis-up? [config]
   (try
-    (let [occ (worker/occupied-queues config)]
-      (vector? occ))
+    (worker/occupied-queues config)
     (catch Exception _ex
       false)))
+
+(defn wrap-health
+  [app config]
+  (fn with-health [req]
+    (let [res (app req)]
+      (if (:health res)
+        (if (redis-up? config)
+          (assoc res :status http-status/ok
+                     :body "OK")
+          (assoc res :status http-status/service-unavailable
+                     :body "Service Unavailable"))
+        res))))

--- a/src/nl/surf/eduhub_rio_mapper/worker.clj
+++ b/src/nl/surf/eduhub_rio_mapper/worker.clj
@@ -129,7 +129,7 @@
                "LEFT"
                "RIGHT"))
 
-(defn- occupied-queues
+(defn occupied-queues
   "Return list of queues having jobs queued."
   [{:keys [redis-conn] {:keys [queues]} :worker :as config}]
   (let [script (apply str "local ids = {};"

--- a/src/nl/surf/eduhub_rio_mapper/worker_api.clj
+++ b/src/nl/surf/eduhub_rio_mapper/worker_api.clj
@@ -1,31 +1,17 @@
 (ns nl.surf.eduhub-rio-mapper.worker-api
   (:require [compojure.core :refer [GET]]
             [compojure.route :as route]
-            [nl.jomco.http-status-codes :as http-status]
             [nl.jomco.ring-trace-context :refer [wrap-trace-context]]
+            [nl.surf.eduhub-rio-mapper.app-server :as app-server]
             [nl.surf.eduhub-rio-mapper.health :as health]
             [nl.surf.eduhub-rio-mapper.logging :refer [wrap-logging]]
-            [ring.adapter.jetty :as jetty]
             [ring.middleware.defaults :as defaults]
-            [ring.middleware.json :refer [wrap-json-response]])
-  (:import [org.eclipse.jetty.server HttpConnectionFactory]))
+            [ring.middleware.json :refer [wrap-json-response]]))
 
 (def public-routes
   (-> (compojure.core/routes
         (GET "/health" []
              {:health true}))))
-
-(defn wrap-health
-  [app config]
-  (fn with-health [req]
-    (let [res (app req)]
-      (if (:health res)
-        (if (health/redis-up? config)
-          (assoc res :status http-status/ok
-                     :body "OK")
-          (assoc res :status http-status/service-unavailable
-                     :body "Service Unavailable"))
-        res))))
 
 (def routes
   (-> (compojure.core/routes
@@ -34,7 +20,7 @@
 
 (defn make-app [config]
   (-> routes
-      (wrap-health config)
+      (health/wrap-health config)
       (wrap-json-response)
       (wrap-logging)
       (wrap-trace-context)
@@ -42,13 +28,4 @@
 
 (defn serve-api
   [{{:keys [^Integer port host]} :worker-api-config :as config}]
-  (jetty/run-jetty (make-app config)
-                   {:host         host
-                    :port         port
-                    :join?        true
-                    ;; Configure Jetty to not send server version
-                    :configurator (fn [jetty]
-                                    (doseq [connector (.getConnectors jetty)]
-                                      (doseq [connFact (.getConnectionFactories connector)]
-                                        (when (instance? HttpConnectionFactory connFact)
-                                          (.setSendServerVersion (.getHttpConfiguration connFact) false)))))}))
+  (app-server/run-jetty (make-app config) host port))

--- a/src/nl/surf/eduhub_rio_mapper/worker_api.clj
+++ b/src/nl/surf/eduhub_rio_mapper/worker_api.clj
@@ -1,0 +1,54 @@
+(ns nl.surf.eduhub-rio-mapper.worker-api
+  (:require [compojure.core :refer [GET]]
+            [compojure.route :as route]
+            [nl.jomco.http-status-codes :as http-status]
+            [nl.jomco.ring-trace-context :refer [wrap-trace-context]]
+            [nl.surf.eduhub-rio-mapper.health :as health]
+            [nl.surf.eduhub-rio-mapper.logging :refer [wrap-logging]]
+            [ring.adapter.jetty :as jetty]
+            [ring.middleware.defaults :as defaults]
+            [ring.middleware.json :refer [wrap-json-response]])
+  (:import [org.eclipse.jetty.server HttpConnectionFactory]))
+
+(def public-routes
+  (-> (compojure.core/routes
+        (GET "/health" []
+             {:health true}))))
+
+(defn wrap-health
+  [app config]
+  (fn with-health [req]
+    (let [res (app req)]
+      (if (:health res)
+        (if (health/redis-up? config)
+          (assoc res :status http-status/ok
+                     :body "OK")
+          (assoc res :status http-status/service-unavailable
+                     :body "Service Unavailable"))
+        res))))
+
+(def routes
+  (-> (compojure.core/routes
+        public-routes
+        (route/not-found nil))))
+
+(defn make-app [config]
+  (-> routes
+      (wrap-health config)
+      (wrap-json-response)
+      (wrap-logging)
+      (wrap-trace-context)
+      (defaults/wrap-defaults defaults/api-defaults)))
+
+(defn serve-api
+  [{{:keys [^Integer port host]} :worker-api-config :as config}]
+  (jetty/run-jetty (make-app config)
+                   {:host         host
+                    :port         port
+                    :join?        true
+                    ;; Configure Jetty to not send server version
+                    :configurator (fn [jetty]
+                                    (doseq [connector (.getConnectors jetty)]
+                                      (doseq [connFact (.getConnectionFactories connector)]
+                                        (when (instance? HttpConnectionFactory connFact)
+                                          (.setSendServerVersion (.getHttpConfiguration connFact) false)))))}))


### PR DESCRIPTION
Adds health endpoints to both the api server and the worker.
Calling /health (no authentication required) will either return 200 or 503.
A 200 code means that the service has managed to start up using the current configuration, and that redis is up and reachable.

Since this PR adds a http server to the worker process, the following two ENV vars are now required:

WORKER_API_HOST
WORKER_API_PORT
