### PR TITLE
Reorganize namespaces

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -5,6 +5,6 @@
   :used-underscored-binding {:level :warning}
   :refer-all {:exclude [clojure.test
                         nl.surf.eduhub-rio-mapper.e2e-helper]}
-  :uninitialized-var {:level :off}} ; bogus report on nl.surf.eduhub-rio-mapper.redis
- :lint-as {nl.surf.eduhub-rio-mapper.redis/defcmd clojure.core/def
-           nl.surf.eduhub-rio-mapper.redis/defcmd+ clojure.core/def}}
+  :uninitialized-var {:level :off}} ; bogus report on nl.surf.eduhub-rio-mapper.utils.redis
+ :lint-as {nl.surf.eduhub-rio-mapper.utils.redis/defcmd clojure.core/def
+           nl.surf.eduhub-rio-mapper.utils.redis/defcmd+ clojure.core/def}}

--- a/project.clj
+++ b/project.clj
@@ -70,7 +70,7 @@
                                                     "--limit-ms" "5000"
                                                     "--include" "nl.surf.*"
                                                     "--require" "nl.surf.eduhub-rio-mapper.ooapi"
-                                                    "--require" "nl.surf.eduhub-rio-mapper.rio"]}}
+                                                    "--require" "nl.surf.eduhub-rio-mapper.rio.rio"]}}
 
              ;; Make tests fail on conflicting deps. This isn't in the
              ;; root of the project.clj, because that will abort any

--- a/src/nl/surf/eduhub_rio_mapper/cli.clj
+++ b/src/nl/surf/eduhub_rio_mapper/cli.clj
@@ -27,19 +27,19 @@
             [nl.jomco.envopts :as envopts]
             [nl.jomco.http-status-codes :as http-status]
             [nl.jomco.ring-trace-context :as trace-context]
-            [nl.surf.eduhub-rio-mapper.api :as api]
             [nl.surf.eduhub-rio-mapper.clients-info :as clients-info]
-            [nl.surf.eduhub-rio-mapper.http-utils :as http-utils]
+            [nl.surf.eduhub-rio-mapper.commands.processing :as processing]
+            [nl.surf.eduhub-rio-mapper.endpoints.api :as api]
+            [nl.surf.eduhub-rio-mapper.endpoints.status :as status]
+            [nl.surf.eduhub-rio-mapper.endpoints.worker-api :as worker-api]
             [nl.surf.eduhub-rio-mapper.job :as job]
-            [nl.surf.eduhub-rio-mapper.keystore :as keystore]
-            [nl.surf.eduhub-rio-mapper.logging :as logging]
             [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
-            [nl.surf.eduhub-rio-mapper.processing :as processing]
-            [nl.surf.eduhub-rio-mapper.rio :as rio]
             [nl.surf.eduhub-rio-mapper.rio.loader :as rio.loader]
-            [nl.surf.eduhub-rio-mapper.status :as status]
-            [nl.surf.eduhub-rio-mapper.worker :as worker]
-            [nl.surf.eduhub-rio-mapper.worker-api :as worker-api])
+            [nl.surf.eduhub-rio-mapper.rio.rio :as rio]
+            [nl.surf.eduhub-rio-mapper.utils.http-utils :as http-utils]
+            [nl.surf.eduhub-rio-mapper.utils.keystore :as keystore]
+            [nl.surf.eduhub-rio-mapper.utils.logging :as logging]
+            [nl.surf.eduhub-rio-mapper.worker :as worker])
   (:gen-class))
 
 (defn parse-int-list [s & _opts] [(mapv #(Integer/parseInt %) (str/split s #","))])

--- a/src/nl/surf/eduhub_rio_mapper/clients_info.clj
+++ b/src/nl/surf/eduhub_rio_mapper/clients_info.clj
@@ -21,7 +21,7 @@
   (:require [clojure.data.json :as json]
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
-            [nl.surf.eduhub-rio-mapper.logging :refer [with-mdc]]))
+            [nl.surf.eduhub-rio-mapper.utils.logging :refer [with-mdc]]))
 
 (s/def ::client-info
   (s/keys :req-un [::client-id]

--- a/src/nl/surf/eduhub_rio_mapper/commands/dry_run.clj
+++ b/src/nl/surf/eduhub_rio_mapper/commands/dry_run.clj
@@ -1,7 +1,7 @@
-(ns nl.surf.eduhub-rio-mapper.dry-run
+(ns nl.surf.eduhub-rio-mapper.commands.dry-run
   (:require [nl.surf.eduhub-rio-mapper.ooapi.common :as common]
             [nl.surf.eduhub-rio-mapper.rio.aangeboden-opleiding :as aangeboden-opleiding]
-            [nl.surf.eduhub-rio-mapper.xml-utils :as xml-utils]))
+            [nl.surf.eduhub-rio-mapper.utils.xml-utils :as xml-utils]))
 
 (def aangeboden-opleiding-namen (->> aangeboden-opleiding/education-specification-type-mapping
                                      vals

--- a/src/nl/surf/eduhub_rio_mapper/commands/link.clj
+++ b/src/nl/surf/eduhub_rio_mapper/commands/link.clj
@@ -1,10 +1,10 @@
-(ns nl.surf.eduhub-rio-mapper.link
+(ns nl.surf.eduhub-rio-mapper.commands.link
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
-            [nl.surf.eduhub-rio-mapper.rio :as rio]
             [nl.surf.eduhub-rio-mapper.rio.loader :as rio.loader]
-            [nl.surf.eduhub-rio-mapper.rio.mutator :as mutator]))
+            [nl.surf.eduhub-rio-mapper.rio.mutator :as mutator]
+            [nl.surf.eduhub-rio-mapper.rio.rio :as rio]))
 
 (defn- strip-duo [kw]
   (-> kw

--- a/src/nl/surf/eduhub_rio_mapper/commands/processing.clj
+++ b/src/nl/surf/eduhub_rio_mapper/commands/processing.clj
@@ -16,23 +16,23 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.processing
+(ns nl.surf.eduhub-rio-mapper.commands.processing
   (:require
     [clojure.spec.alpha :as s]
     [clojure.tools.logging :as log]
     [nl.jomco.http-status-codes :as http-status]
-    [nl.surf.eduhub-rio-mapper.dry-run :as dry-run]
-    [nl.surf.eduhub-rio-mapper.link :as link]
-    [nl.surf.eduhub-rio-mapper.logging :as logging]
+    [nl.surf.eduhub-rio-mapper.commands.dry-run :as dry-run]
+    [nl.surf.eduhub-rio-mapper.commands.link :as link]
     [nl.surf.eduhub-rio-mapper.Mutation :as-alias Mutation]
     [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
     [nl.surf.eduhub-rio-mapper.ooapi.loader :as ooapi.loader]
-    [nl.surf.eduhub-rio-mapper.relation-handler :as relation-handler]
-    [nl.surf.eduhub-rio-mapper.rio :as rio]
     [nl.surf.eduhub-rio-mapper.rio.loader :as rio.loader]
     [nl.surf.eduhub-rio-mapper.rio.mutator :as mutator]
-    [nl.surf.eduhub-rio-mapper.updated-handler :as updated-handler]
-    [nl.surf.eduhub-rio-mapper.xml-utils :as xml-utils]))
+    [nl.surf.eduhub-rio-mapper.rio.relation-handler :as relation-handler]
+    [nl.surf.eduhub-rio-mapper.rio.rio :as rio]
+    [nl.surf.eduhub-rio-mapper.rio.updated-handler :as updated-handler]
+    [nl.surf.eduhub-rio-mapper.utils.logging :as logging]
+    [nl.surf.eduhub-rio-mapper.utils.xml-utils :as xml-utils]))
 
 (defn- extract-eduspec-from-result [result]
   (let [entity (:ooapi result)]

--- a/src/nl/surf/eduhub_rio_mapper/endpoints/api.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/api.clj
@@ -16,24 +16,24 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.api
+(ns nl.surf.eduhub-rio-mapper.endpoints.api
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as str]
             [compojure.core :refer [GET POST]]
             [compojure.route :as route]
             [nl.jomco.http-status-codes :as http-status]
             [nl.jomco.ring-trace-context :refer [wrap-trace-context]]
-            [nl.surf.eduhub-rio-mapper.api.authentication :as authentication]
-            [nl.surf.eduhub-rio-mapper.app-server :as app-server]
             [nl.surf.eduhub-rio-mapper.clients-info :refer [wrap-client-info] :as clients-info]
-            [nl.surf.eduhub-rio-mapper.health :as health]
+            [nl.surf.eduhub-rio-mapper.endpoints.app-server :as app-server]
+            [nl.surf.eduhub-rio-mapper.endpoints.health :as health]
+            [nl.surf.eduhub-rio-mapper.endpoints.metrics :as metrics]
+            [nl.surf.eduhub-rio-mapper.endpoints.status :as status]
             [nl.surf.eduhub-rio-mapper.job :as job]
-            [nl.surf.eduhub-rio-mapper.logging :refer [with-mdc wrap-logging]]
-            [nl.surf.eduhub-rio-mapper.metrics :as metrics]
             [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
             [nl.surf.eduhub-rio-mapper.ooapi.common :as common]
-            [nl.surf.eduhub-rio-mapper.rio :as rio]
-            [nl.surf.eduhub-rio-mapper.status :as status]
+            [nl.surf.eduhub-rio-mapper.rio.rio :as rio]
+            [nl.surf.eduhub-rio-mapper.utils.authentication :as authentication]
+            [nl.surf.eduhub-rio-mapper.utils.logging :refer [with-mdc wrap-logging]]
             [nl.surf.eduhub-rio-mapper.worker :as worker]
             [ring.middleware.defaults :as defaults]
             [ring.middleware.json :refer [wrap-json-response]]

--- a/src/nl/surf/eduhub_rio_mapper/endpoints/app_server.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/app_server.clj
@@ -1,4 +1,4 @@
-(ns nl.surf.eduhub-rio-mapper.app-server
+(ns nl.surf.eduhub-rio-mapper.endpoints.app-server
   (:require [ring.adapter.jetty :as jetty])
   (:import [org.eclipse.jetty.server HttpConnectionFactory]))
 

--- a/src/nl/surf/eduhub_rio_mapper/endpoints/health.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/health.clj
@@ -1,4 +1,4 @@
-(ns nl.surf.eduhub-rio-mapper.health
+(ns nl.surf.eduhub-rio-mapper.endpoints.health
   (:require [nl.jomco.http-status-codes :as http-status]
             [nl.surf.eduhub-rio-mapper.worker :as worker]))
 

--- a/src/nl/surf/eduhub_rio_mapper/endpoints/metrics.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/metrics.clj
@@ -1,6 +1,6 @@
-(ns nl.surf.eduhub-rio-mapper.metrics
+(ns nl.surf.eduhub-rio-mapper.endpoints.metrics
   (:require [clojure.string :as str]
-            [nl.surf.eduhub-rio-mapper.redis :as redis]))
+            [nl.surf.eduhub-rio-mapper.utils.redis :as redis]))
 
 (def jobs-count-by-status-key-name "jobs-count-by-status")
 

--- a/src/nl/surf/eduhub_rio_mapper/endpoints/status.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/status.clj
@@ -16,8 +16,8 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.status
-  (:require [nl.surf.eduhub-rio-mapper.redis :as redis])
+(ns nl.surf.eduhub-rio-mapper.endpoints.status
+  (:require [nl.surf.eduhub-rio-mapper.utils.redis :as redis])
   (:refer-clojure :exclude [get]))
 
 (defn- status-key

--- a/src/nl/surf/eduhub_rio_mapper/endpoints/worker_api.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/worker_api.clj
@@ -1,10 +1,10 @@
-(ns nl.surf.eduhub-rio-mapper.worker-api
+(ns nl.surf.eduhub-rio-mapper.endpoints.worker-api
   (:require [compojure.core :refer [GET]]
             [compojure.route :as route]
             [nl.jomco.ring-trace-context :refer [wrap-trace-context]]
-            [nl.surf.eduhub-rio-mapper.app-server :as app-server]
-            [nl.surf.eduhub-rio-mapper.health :as health]
-            [nl.surf.eduhub-rio-mapper.logging :refer [wrap-logging]]
+            [nl.surf.eduhub-rio-mapper.endpoints.app-server :as app-server]
+            [nl.surf.eduhub-rio-mapper.endpoints.health :as health]
+            [nl.surf.eduhub-rio-mapper.utils.logging :refer [wrap-logging]]
             [ring.middleware.defaults :as defaults]
             [ring.middleware.json :refer [wrap-json-response]]))
 

--- a/src/nl/surf/eduhub_rio_mapper/job.clj
+++ b/src/nl/surf/eduhub_rio_mapper/job.clj
@@ -19,10 +19,10 @@
 (ns nl.surf.eduhub-rio-mapper.job
   (:require [clojure.tools.logging :as log]
             [nl.jomco.ring-trace-context :refer [with-context]]
-            [nl.surf.eduhub-rio-mapper.http-utils :refer [*http-messages*]]
-            [nl.surf.eduhub-rio-mapper.logging :as logging]
             [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
-            [nl.surf.eduhub-rio-mapper.rio :as rio])
+            [nl.surf.eduhub-rio-mapper.rio.rio :as rio]
+            [nl.surf.eduhub-rio-mapper.utils.http-utils :refer [*http-messages*]]
+            [nl.surf.eduhub-rio-mapper.utils.logging :as logging])
   (:import java.util.UUID)
   (:refer-clojure :exclude [run!]))
 

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/common.clj
@@ -28,7 +28,7 @@
             [nl.surf.eduhub-rio-mapper.ooapi.rio-consumer :as-alias rio-consumer]
             [nl.surf.eduhub-rio-mapper.ooapi.StudyLoadDescriptor :as-alias StudyLoadDescriptor]
             [nl.surf.eduhub-rio-mapper.re-spec :refer [re-spec text-spec looks-like-html?]]
-            [nl.surf.eduhub-rio-mapper.rio :as rio])
+            [nl.surf.eduhub-rio-mapper.rio.rio :as rio])
   (:import (java.time LocalDate)
            (java.time.format DateTimeFormatter DateTimeParseException)
            (java.util UUID)))

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
@@ -20,14 +20,14 @@
   (:require [clojure.data.json :as json]
             [clojure.spec.alpha :as s]
             [nl.jomco.http-status-codes :as http-status]
-            [nl.surf.eduhub-rio-mapper.http-utils :as http-utils]
             [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
             [nl.surf.eduhub-rio-mapper.ooapi.common :as common]
             [nl.surf.eduhub-rio-mapper.ooapi.course :as course]
             [nl.surf.eduhub-rio-mapper.ooapi.education-specification :as education-specification]
             [nl.surf.eduhub-rio-mapper.ooapi.offerings :as offerings]
             [nl.surf.eduhub-rio-mapper.ooapi.program :as program]
-            [nl.surf.eduhub-rio-mapper.rio :as rio])
+            [nl.surf.eduhub-rio-mapper.rio.rio :as rio]
+            [nl.surf.eduhub-rio-mapper.utils.http-utils :as http-utils])
   (:import [java.net URI]))
 
 ;; This limit will be lifted later, to be replaced by pagination.

--- a/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
@@ -19,7 +19,7 @@
 (ns nl.surf.eduhub-rio-mapper.rio.aangeboden-opleiding
   (:require [clojure.string :as str]
             [nl.surf.eduhub-rio-mapper.ooapi.common :as common]
-            [nl.surf.eduhub-rio-mapper.rio :as rio])
+            [nl.surf.eduhub-rio-mapper.rio.rio :as rio])
   (:import [java.time Period Duration]))
 
 (defn- parse-duration [duration]

--- a/src/nl/surf/eduhub_rio_mapper/rio/loader.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/loader.clj
@@ -23,14 +23,14 @@
     [clojure.data.xml :as clj-xml]
     [clojure.spec.alpha :as s]
     [clojure.tools.logging :as log]
-    [nl.surf.eduhub-rio-mapper.http-utils :as http-utils]
-    [nl.surf.eduhub-rio-mapper.logging :as logging]
     [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
     [nl.surf.eduhub-rio-mapper.Relation :as-alias Relation]
-    [nl.surf.eduhub-rio-mapper.rio :as rio]
-    [nl.surf.eduhub-rio-mapper.soap :as soap]
-    [nl.surf.eduhub-rio-mapper.xml-utils :as xml-utils]
-    [nl.surf.eduhub-rio-mapper.xml-validator :as xml-validator])
+    [nl.surf.eduhub-rio-mapper.rio.rio :as rio]
+    [nl.surf.eduhub-rio-mapper.utils.http-utils :as http-utils]
+    [nl.surf.eduhub-rio-mapper.utils.logging :as logging]
+    [nl.surf.eduhub-rio-mapper.utils.soap :as soap]
+    [nl.surf.eduhub-rio-mapper.utils.xml-utils :as xml-utils]
+    [nl.surf.eduhub-rio-mapper.utils.xml-validator :as xml-validator])
   (:import (org.w3c.dom Element)))
 
 (def aangeboden-opleiding "aangebodenOpleiding")

--- a/src/nl/surf/eduhub_rio_mapper/rio/mutator.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/mutator.clj
@@ -19,12 +19,12 @@
 (ns nl.surf.eduhub-rio-mapper.rio.mutator
   (:require [clojure.data.xml :as clj-xml]
             [clojure.spec.alpha :as s]
-            [nl.surf.eduhub-rio-mapper.http-utils :as http-utils]
             [nl.surf.eduhub-rio-mapper.Mutation :as-alias Mutation]
             [nl.surf.eduhub-rio-mapper.rio.loader :as loader]
-            [nl.surf.eduhub-rio-mapper.soap :as soap]
-            [nl.surf.eduhub-rio-mapper.xml-utils :as xml-utils]
-            [nl.surf.eduhub-rio-mapper.xml-validator :as xml-validator])
+            [nl.surf.eduhub-rio-mapper.utils.http-utils :as http-utils]
+            [nl.surf.eduhub-rio-mapper.utils.soap :as soap]
+            [nl.surf.eduhub-rio-mapper.utils.xml-utils :as xml-utils]
+            [nl.surf.eduhub-rio-mapper.utils.xml-validator :as xml-validator])
   (:import (org.w3c.dom Element)))
 
 (def schema

--- a/src/nl/surf/eduhub_rio_mapper/rio/opleidingseenheid.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/opleidingseenheid.clj
@@ -19,7 +19,7 @@
 (ns nl.surf.eduhub-rio-mapper.rio.opleidingseenheid
   (:require [clojure.string :as str]
             [nl.surf.eduhub-rio-mapper.ooapi.common :as common]
-            [nl.surf.eduhub-rio-mapper.rio :as rio]))
+            [nl.surf.eduhub-rio-mapper.rio.rio :as rio]))
 
 (def ^:private education-specification-type-mapping
   {"course"         "hoOnderwijseenheid"

--- a/src/nl/surf/eduhub_rio_mapper/rio/relation_handler.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/relation_handler.clj
@@ -16,7 +16,7 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.relation-handler
+(ns nl.surf.eduhub-rio-mapper.rio.relation-handler
   (:require [clojure.set :as set]
             [clojure.spec.alpha :as s]
             [nl.surf.eduhub-rio-mapper.Mutation :as-alias Mutation]
@@ -25,8 +25,8 @@
             [nl.surf.eduhub-rio-mapper.Relation :as-alias Relation]
             [nl.surf.eduhub-rio-mapper.RelationChild :as-alias RelationChild]
             [nl.surf.eduhub-rio-mapper.RelationParent :as-alias RelationParent]
-            [nl.surf.eduhub-rio-mapper.rio :as rio]
-            [nl.surf.eduhub-rio-mapper.rio.mutator :as mutator]))
+            [nl.surf.eduhub-rio-mapper.rio.mutator :as mutator]
+            [nl.surf.eduhub-rio-mapper.rio.rio :as rio]))
 
 (s/def ::Relation/opleidingseenheidcodes
   (s/and set? (s/coll-of string?)))

--- a/src/nl/surf/eduhub_rio_mapper/rio/rio.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/rio.clj
@@ -16,7 +16,8 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.rio
+;; TODO rename to e.g. common
+(ns nl.surf.eduhub-rio-mapper.rio.rio
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
@@ -31,6 +32,7 @@
 (def specifications (edn/read (PushbackReader. (io/reader (io/resource "ooapi-mappings.edn")))))
 (def xsd-beheren (edn/read (PushbackReader. (io/reader (io/resource "beheren-schema.edn")))))
 
+;; TODO move to aangeboden opleiding
 (defn ooapi-mapping? [name]
   (boolean (get-in specifications [:mappings name])))
 
@@ -99,7 +101,7 @@
       ;; http://uis.unesco.org/sites/default/files/documents/isced-fields-of-education-and-training-2013-en.pdf
       (subs s 0 3))))
 
-(defn kenmerken [name type value]
+(defn- kenmerken [name type value]
   (when value
      [:duo:kenmerken
        [:duo:kenmerknaam name]
@@ -107,11 +109,11 @@
 
 ;;; XML generation
 
-(defn name->type [nm]
+(defn- name->type [nm]
   {:pre [(string? nm)]}
   (str (str/upper-case (subs nm 0 1)) (subs nm 1)))
 
-(defn duoize [naam]
+(defn- duoize [naam]
   (keyword (str "duo:" (if (keyword? naam) (name naam) naam))))
 
 (def attr-name->kenmerk-type-mapping
@@ -135,7 +137,7 @@
    "vorm" :enum
    "website" :string})
 
-(defn attr-name->kenmerk-type [attr-name]
+(defn- attr-name->kenmerk-type [attr-name]
   (if-let [type (attr-name->kenmerk-type-mapping attr-name)]
     type
     (do
@@ -143,7 +145,7 @@
       (log/warnf "Missing type for kenmerk (%s), assuming it's :enum" attr-name)
       :enum)))
 
-(defn process-attribute [attr-name attr-value kenmerk]
+(defn- process-attribute [attr-name attr-value kenmerk]
   (condp apply [attr-value]
     vector?
     (->> attr-value

--- a/src/nl/surf/eduhub_rio_mapper/rio/updated_handler.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/updated_handler.clj
@@ -16,14 +16,14 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.updated-handler
+(ns nl.surf.eduhub-rio-mapper.rio.updated-handler
   (:require [clojure.spec.alpha :as s]
             [nl.surf.eduhub-rio-mapper.Mutation :as-alias Mutation]
             [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
-            [nl.surf.eduhub-rio-mapper.relation-handler :as relation-handler]
-            [nl.surf.eduhub-rio-mapper.rio :as rio]
             [nl.surf.eduhub-rio-mapper.rio.aangeboden-opleiding :as aangeboden-opl]
-            [nl.surf.eduhub-rio-mapper.rio.opleidingseenheid :as opl-eenh]))
+            [nl.surf.eduhub-rio-mapper.rio.opleidingseenheid :as opl-eenh]
+            [nl.surf.eduhub-rio-mapper.rio.relation-handler :as relation-handler]
+            [nl.surf.eduhub-rio-mapper.rio.rio :as rio]))
 
 ;; We have full entities in the request for upserts and then we need to
 ;; also fetch the education-specification from the entity if it's a

--- a/src/nl/surf/eduhub_rio_mapper/utils/authentication.clj
+++ b/src/nl/surf/eduhub_rio_mapper/utils/authentication.clj
@@ -16,7 +16,7 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.api.authentication
+(ns nl.surf.eduhub-rio-mapper.utils.authentication
   "Authenticate incoming HTTP API requests using SURFconext.
 
   This uses the OAuth2 Client Credentials flow for authentication. From
@@ -40,7 +40,7 @@
             [clojure.core.memoize :as memo]
             [clojure.tools.logging :as log]
             [nl.jomco.http-status-codes :as http-status]
-            [nl.surf.eduhub-rio-mapper.logging :refer [with-mdc]]
+            [nl.surf.eduhub-rio-mapper.utils.logging :refer [with-mdc]]
             [ring.util.response :as response]))
 
 (defn bearer-token

--- a/src/nl/surf/eduhub_rio_mapper/utils/exception_utils.clj
+++ b/src/nl/surf/eduhub_rio_mapper/utils/exception_utils.clj
@@ -1,4 +1,4 @@
-(ns nl.surf.eduhub-rio-mapper.exception-utils
+(ns nl.surf.eduhub-rio-mapper.utils.exception-utils
   (:require [clojure.stacktrace :as trace]
             [clojure.string :as str]))
 

--- a/src/nl/surf/eduhub_rio_mapper/utils/http_utils.clj
+++ b/src/nl/surf/eduhub_rio_mapper/utils/http_utils.clj
@@ -16,7 +16,7 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.http-utils
+(ns nl.surf.eduhub-rio-mapper.utils.http-utils
   (:require [clj-http.client :as http]
             [clojure.tools.logging :as log]
             [nl.jomco.http-status-codes :as http-status]

--- a/src/nl/surf/eduhub_rio_mapper/utils/keystore.clj
+++ b/src/nl/surf/eduhub_rio_mapper/utils/keystore.clj
@@ -16,7 +16,7 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.keystore
+(ns nl.surf.eduhub-rio-mapper.utils.keystore
   (:require [clojure.java.io :as io])
   (:import (java.security KeyStore
                           KeyStore$PasswordProtection

--- a/src/nl/surf/eduhub_rio_mapper/utils/logging.clj
+++ b/src/nl/surf/eduhub_rio_mapper/utils/logging.clj
@@ -16,7 +16,7 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.logging
+(ns nl.surf.eduhub-rio-mapper.utils.logging
   (:require [clojure.string :as string]
             [clojure.tools.logging :as log]
             [nl.jomco.http-status-codes :as http-status])

--- a/src/nl/surf/eduhub_rio_mapper/utils/redis.clj
+++ b/src/nl/surf/eduhub_rio_mapper/utils/redis.clj
@@ -16,7 +16,7 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.redis
+(ns nl.surf.eduhub-rio-mapper.utils.redis
   (:require [clojure.string :refer [upper-case]]
             [taoensso.carmine :as car :refer [wcar]]
             [taoensso.carmine.commands :as carcmd])

--- a/src/nl/surf/eduhub_rio_mapper/utils/soap.clj
+++ b/src/nl/surf/eduhub_rio_mapper/utils/soap.clj
@@ -16,13 +16,13 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.soap
+(ns nl.surf.eduhub-rio-mapper.utils.soap
   (:require
    [clojure.data.xml :as clj-xml]
    [clojure.spec.alpha :as s]
    [clojure.string :as string]
    [nl.surf.eduhub-rio-mapper.re-spec :refer [re-spec]]
-   [nl.surf.eduhub-rio-mapper.xml-utils :as xml-utils])
+   [nl.surf.eduhub-rio-mapper.utils.xml-utils :as xml-utils])
   (:import
    (java.io ByteArrayOutputStream)
    (java.nio.charset StandardCharsets)

--- a/src/nl/surf/eduhub_rio_mapper/utils/xml_utils.clj
+++ b/src/nl/surf/eduhub_rio_mapper/utils/xml_utils.clj
@@ -16,7 +16,7 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.xml-utils
+(ns nl.surf.eduhub-rio-mapper.utils.xml-utils
   (:require [clojure.data.xml :as clj-xml])
   (:import [java.io StringReader StringWriter]
            [javax.xml.parsers DocumentBuilderFactory]

--- a/src/nl/surf/eduhub_rio_mapper/utils/xml_validator.clj
+++ b/src/nl/surf/eduhub_rio_mapper/utils/xml_validator.clj
@@ -16,7 +16,7 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.xml-validator
+(ns nl.surf.eduhub-rio-mapper.utils.xml-validator
   (:require [clojure.java.io :as io])
   (:import java.io.StringReader
            javax.xml.XMLConstants

--- a/src/nl/surf/eduhub_rio_mapper/worker.clj
+++ b/src/nl/surf/eduhub_rio_mapper/worker.clj
@@ -19,10 +19,10 @@
 (ns nl.surf.eduhub-rio-mapper.worker
   (:require [clojure.core.async :as async]
             [clojure.tools.logging :as log]
-            [nl.surf.eduhub-rio-mapper.exception-utils :as ex-util]
-            [nl.surf.eduhub-rio-mapper.logging :as logging]
-            [nl.surf.eduhub-rio-mapper.metrics :as metrics]
-            [nl.surf.eduhub-rio-mapper.redis :as redis]
+            [nl.surf.eduhub-rio-mapper.endpoints.metrics :as metrics]
+            [nl.surf.eduhub-rio-mapper.utils.exception-utils :as ex-util]
+            [nl.surf.eduhub-rio-mapper.utils.logging :as logging]
+            [nl.surf.eduhub-rio-mapper.utils.redis :as redis]
             [taoensso.carmine :as car])
   (:import java.io.EOFException
            java.util.UUID))

--- a/test/nl/surf/eduhub_rio_mapper/e2e_helper.clj
+++ b/test/nl/surf/eduhub_rio_mapper/e2e_helper.clj
@@ -9,12 +9,12 @@
             [nl.jomco.http-status-codes :as http-status]
             [nl.surf.eduhub-rio-mapper.cli :as cli]
             [nl.surf.eduhub-rio-mapper.clients-info :as clients-info]
-            [nl.surf.eduhub-rio-mapper.http-utils :as http-utils]
             [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
             [nl.surf.eduhub-rio-mapper.remote-entities-helper :as remote-entities]
-            [nl.surf.eduhub-rio-mapper.rio :as rio]
             [nl.surf.eduhub-rio-mapper.rio.loader :as rio-loader]
-            [nl.surf.eduhub-rio-mapper.xml-utils :as xml-utils])
+            [nl.surf.eduhub-rio-mapper.rio.rio :as rio]
+            [nl.surf.eduhub-rio-mapper.utils.http-utils :as http-utils]
+            [nl.surf.eduhub-rio-mapper.utils.xml-utils :as xml-utils])
   (:import (java.util Base64)
            (java.io ByteArrayInputStream StringWriter)
            (javax.xml.xpath XPathFactory)))

--- a/test/nl/surf/eduhub_rio_mapper/endpoints/api_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/endpoints/api_test.clj
@@ -16,15 +16,15 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.api-test
+(ns nl.surf.eduhub-rio-mapper.endpoints.api-test
   (:require [clojure.test :refer :all]
             [nl.jomco.http-status-codes :as http-status]
-            [nl.surf.eduhub-rio-mapper.api :as api]
             [nl.surf.eduhub-rio-mapper.cli :as cli]
+            [nl.surf.eduhub-rio-mapper.endpoints.api :as api]
+            [nl.surf.eduhub-rio-mapper.endpoints.status :as status]
             [nl.surf.eduhub-rio-mapper.job :as job]
             [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
-            [nl.surf.eduhub-rio-mapper.rio :as rio]
-            [nl.surf.eduhub-rio-mapper.status :as status]
+            [nl.surf.eduhub-rio-mapper.rio.rio :as rio]
             [ring.mock.request :refer [request]]))
 
 (defn authenticated-request [method path]

--- a/test/nl/surf/eduhub_rio_mapper/mapper_integration_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/mapper_integration_test.clj
@@ -22,12 +22,12 @@
     [clojure.java.io :as io]
     [clojure.string :as str]
     [clojure.test :refer :all]
-    [nl.surf.eduhub-rio-mapper.keystore :as keystore]
     [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
     [nl.surf.eduhub-rio-mapper.ooapi.loader :as ooapi.loader]
     [nl.surf.eduhub-rio-mapper.rio.mutator :as mutator]
+    [nl.surf.eduhub-rio-mapper.rio.updated-handler :as updated-handler]
     [nl.surf.eduhub-rio-mapper.test-helper :refer [load-json]]
-    [nl.surf.eduhub-rio-mapper.updated-handler :as updated-handler]))
+    [nl.surf.eduhub-rio-mapper.utils.keystore :as keystore]))
 
 (def institution-oin "123O321")
 (def rio-opleidingsid "1234O1234")

--- a/test/nl/surf/eduhub_rio_mapper/metrics_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/metrics_test.clj
@@ -1,6 +1,6 @@
 (ns nl.surf.eduhub-rio-mapper.metrics-test
   (:require [clojure.test :refer :all]
-            [nl.surf.eduhub-rio-mapper.metrics :as metrics]))
+            [nl.surf.eduhub-rio-mapper.endpoints.metrics :as metrics]))
 
 (deftest render-metrics
   (is (= (str "rio_mapper_jobs_total{schac_home=\"meta\", institution_name=\"facebook\", job_status=\"done\"} 321\n"

--- a/test/nl/surf/eduhub_rio_mapper/ooapi/loader_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/ooapi/loader_test.clj
@@ -21,10 +21,10 @@
     [clojure.test :refer :all]
     [nl.surf.eduhub-rio-mapper.cli :as cli]
     [nl.surf.eduhub-rio-mapper.clients-info :as clients-info]
-    [nl.surf.eduhub-rio-mapper.http-utils :as http-utils]
     [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
     [nl.surf.eduhub-rio-mapper.ooapi.loader :as ooapi.loader]
-    [nl.surf.eduhub-rio-mapper.test-helper :as helper])
+    [nl.surf.eduhub-rio-mapper.test-helper :as helper]
+    [nl.surf.eduhub-rio-mapper.utils.http-utils :as http-utils])
   (:import [java.net URI]))
 
 (defn- make-vcr [method]

--- a/test/nl/surf/eduhub_rio_mapper/processing_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/processing_test.clj
@@ -18,7 +18,7 @@
 
 (ns nl.surf.eduhub-rio-mapper.processing-test
   (:require [clojure.test :refer :all]
-            [nl.surf.eduhub-rio-mapper.processing :as processing]))
+            [nl.surf.eduhub-rio-mapper.commands.processing :as processing]))
 
 (deftest test-blocking-retry
   (let [retry-3-times #(processing/blocking-retry % [0.001 0.001 0.001] nil)]

--- a/test/nl/surf/eduhub_rio_mapper/relation_handler_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/relation_handler_test.clj
@@ -22,12 +22,12 @@
     [clojure.data.json :as json]
     [clojure.java.io :as io]
     [clojure.test :refer :all]
-    [nl.surf.eduhub-rio-mapper.keystore :as keystore]
     [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
-    [nl.surf.eduhub-rio-mapper.relation-handler :as rh]
-    [nl.surf.eduhub-rio-mapper.rio :as rio]
     [nl.surf.eduhub-rio-mapper.rio.mutator :as mutator]
-    [nl.surf.eduhub-rio-mapper.soap :as soap]))
+    [nl.surf.eduhub-rio-mapper.rio.relation-handler :as rh]
+    [nl.surf.eduhub-rio-mapper.rio.rio :as rio]
+    [nl.surf.eduhub-rio-mapper.utils.keystore :as keystore]
+    [nl.surf.eduhub-rio-mapper.utils.soap :as soap]))
 
 (def education-specification (-> "fixtures/ooapi/education-specification.json"
                                  io/resource

--- a/test/nl/surf/eduhub_rio_mapper/rio/opleidingseenheid_finder_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/rio/opleidingseenheid_finder_test.clj
@@ -1,6 +1,6 @@
 (ns nl.surf.eduhub-rio-mapper.rio.opleidingseenheid-finder-test
   (:require [clojure.test :refer :all]
-            [nl.surf.eduhub-rio-mapper.dry-run :as dry-run]))
+            [nl.surf.eduhub-rio-mapper.commands.dry-run :as dry-run]))
 
 (defn generate-diff [a b] (dry-run/generate-diff-ooapi-rio {:rio-summary a :ooapi-summary b}))
 

--- a/test/nl/surf/eduhub_rio_mapper/rio_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/rio_test.clj
@@ -23,16 +23,16 @@
             [clojure.java.io :as io]
             [clojure.test :refer [are deftest is testing]]
             [nl.surf.eduhub-rio-mapper.clients-info :as clients-info]
-            [nl.surf.eduhub-rio-mapper.keystore :as keystore]
             [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
             [nl.surf.eduhub-rio-mapper.ooapi.loader :as ooapi.loader]
             [nl.surf.eduhub-rio-mapper.rio.aangeboden-opleiding :as aangeboden-opl]
             [nl.surf.eduhub-rio-mapper.rio.loader :as rio.loader]
             [nl.surf.eduhub-rio-mapper.rio.mutator :as mutator]
             [nl.surf.eduhub-rio-mapper.rio.opleidingseenheid :as opl-eenh]
-            [nl.surf.eduhub-rio-mapper.soap :as soap]
-            [nl.surf.eduhub-rio-mapper.updated-handler :as updated-handler]
-            [nl.surf.eduhub-rio-mapper.xml-utils :as xml-utils])
+            [nl.surf.eduhub-rio-mapper.rio.updated-handler :as updated-handler]
+            [nl.surf.eduhub-rio-mapper.utils.keystore :as keystore]
+            [nl.surf.eduhub-rio-mapper.utils.soap :as soap]
+            [nl.surf.eduhub-rio-mapper.utils.xml-utils :as xml-utils])
   (:import clojure.lang.ExceptionInfo
            java.io.PushbackReader))
 

--- a/test/nl/surf/eduhub_rio_mapper/smoke_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/smoke_test.clj
@@ -24,14 +24,14 @@
     [clojure.test :refer :all]
     [nl.surf.eduhub-rio-mapper.cli :as cli]
     [nl.surf.eduhub-rio-mapper.clients-info :as clients-info]
-    [nl.surf.eduhub-rio-mapper.dry-run :as dry-run]
-    [nl.surf.eduhub-rio-mapper.http-utils :as http-utils]
+    [nl.surf.eduhub-rio-mapper.commands.dry-run :as dry-run]
+    [nl.surf.eduhub-rio-mapper.commands.processing :as processing]
     [nl.surf.eduhub-rio-mapper.job :as job]
     [nl.surf.eduhub-rio-mapper.ooapi :as ooapi]
-    [nl.surf.eduhub-rio-mapper.processing :as processing]
-    [nl.surf.eduhub-rio-mapper.rio :as rio]
     [nl.surf.eduhub-rio-mapper.rio.loader :as rio.loader]
-    [nl.surf.eduhub-rio-mapper.test-helper :as helper])
+    [nl.surf.eduhub-rio-mapper.rio.rio :as rio]
+    [nl.surf.eduhub-rio-mapper.test-helper :as helper]
+    [nl.surf.eduhub-rio-mapper.utils.http-utils :as http-utils])
   (:import [clojure.lang ExceptionInfo]))
 
 (defn- load-relations [getter client-info code]

--- a/test/nl/surf/eduhub_rio_mapper/utils/authentication_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/utils/authentication_test.clj
@@ -16,11 +16,11 @@
 ;; License along with this program.  If not, see
 ;; <https://www.gnu.org/licenses/>.
 
-(ns nl.surf.eduhub-rio-mapper.api.authentication-test
+(ns nl.surf.eduhub-rio-mapper.utils.authentication-test
   (:require [clj-http.client :as client]
             [clojure.test :refer :all]
             [nl.jomco.http-status-codes :as http-status]
-            [nl.surf.eduhub-rio-mapper.api.authentication :as authentication]))
+            [nl.surf.eduhub-rio-mapper.utils.authentication :as authentication]))
 
 (deftest test-bearer-token
   (is (nil?


### PR DESCRIPTION
I moved most namespaces in eduhub-mapper to separate folders:

commands: rio commands, such as dry-run, link, upsert, delete
endpoints: anything related to accessing the api and worker apps via http
utils: namespaces with stand-alone utility functions (xml, soap, redis, logging, keystore)
rio: rio-specific namespaces modeling rio objects, such as aangeboden opleiding, opleidingseenheid and relations.

There is more cleanup to be done, but I want to get this out of the way first.