### PR TITLE
Support `lein mapper show programs`

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -76,6 +76,14 @@ lein mapper delete-by-code uni-id education-specification 1234O1234
 
 The `show` command retrieves data from OOAPI. The following entities are supported:
 
+#### courses
+
+Example:
+
+```sh
+lein mapper show uni-id courses
+```
+
 #### course
 
 Example:
@@ -84,12 +92,28 @@ Example:
 lein mapper show uni-id course 123e4567-e89b-12d3-a456-426655440000
 ```
 
+#### programs
+
+Example:
+
+```sh
+lein mapper show uni-id programs
+```
+
 #### program
 
 Example:
 
 ```sh
 lein mapper show uni-id program 123e4567-e89b-12d3-a456-426655440000
+```
+
+#### education-specifications
+
+Example:
+
+```sh
+lein mapper show uni-id education-specifications
 ```
 
 #### education-specification

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
@@ -39,19 +39,19 @@
   250)
 
 (defn- ooapi-type->path [ooapi-type id page]
-  (let [page-suffix (if page (str "&pageNumber=" page) "")
-        path (case ooapi-type
-               "education-specification" "education-specifications/%s?returnTimelineOverrides=true"
-               "education-specifications" "education-specifications"
-               "program" "programs/%s?returnTimelineOverrides=true"
-               "programs" "programs"
-               "course" "courses/%s?returnTimelineOverrides=true"
-               "courses" "courses"
-               "course-offerings" (str "courses/%s/offerings?pageSize=" max-offerings "&consumer=rio" page-suffix)
-               "program-offerings" (str "programs/%s/offerings?pageSize=" max-offerings "&consumer=rio" page-suffix))]
-    (if id
-      (format path id)
-      path)))
+  (if id
+    (let [page-suffix (if page (str "&pageNumber=" page) "")
+          path        (case ooapi-type
+                        "education-specification" "education-specifications/%s?returnTimelineOverrides=true"
+                        "program" "programs/%s?returnTimelineOverrides=true"
+                        "course" "courses/%s?returnTimelineOverrides=true"
+                        "course-offerings" (str "courses/%s/offerings?pageSize=" max-offerings "&consumer=rio" page-suffix)
+                        "program-offerings" (str "programs/%s/offerings?pageSize=" max-offerings "&consumer=rio" page-suffix))]
+      (format path id))
+    (case ooapi-type
+      "education-specifications" "education-specifications"
+      "programs" "programs"
+      "courses" "courses")))
 
 (defn ooapi-http-loader
   [{::ooapi/keys [root-url type id]

--- a/test/nl/surf/eduhub_rio_mapper/ooapi/loader_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/ooapi/loader_test.clj
@@ -41,5 +41,5 @@
                       ::ooapi/id       "6456b864-c121-bb61-fda2-109251a1c777"
                       :gateway-credentials (:gateway-credentials config)}]
     (binding [http-utils/*vcr* (vcr "test/fixtures/ooapi-loader" 1 "offering")]
-      (let [items (ooapi-loader (merge client-info request {:page-size 2}))]
+      (let [items (:items (ooapi-loader (merge client-info request {:page-size 2})))]
         (is (= 3 (count items)))))))


### PR DESCRIPTION
Expanded support for querying ooapi via the command line.

Now supports `lein mapper show CLIENT TYPE` where type is programs, courses, or education-specifications.
This makes it easier to find an ooapi entity for testing purposes, e.g. "quick, give me an program id for `lein mapper upsert program`.
