### PR TITLE
Fixed callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ CLIENTS_INFO_PATH                   CLients info config file
 GATEWAY_PASSWORD                    OOAPI Gateway Password
 GATEWAY_ROOT_URL                    OOAPI Gateway Root URL
 GATEWAY_USER                        OOAPI Gateway Username
-HTTP_MESSAGES                       Boolean; should all http traffic be logged? Defaults to false.
 JOB_MAX_RETRIES                     Max number of retries of a failed job
 JOB_RETRY_WAIT_MS                   Number of milliseconds to wait before retrying a failed job
 KEYSTORE                            Path to keystore
@@ -157,6 +156,7 @@ RIO_READ_URL                        RIO Services Read URL
 RIO_RECIPIENT_OIN                   Recipient OIN for RIO SOAP calls
 RIO_UPDATE_URL                      RIO Services Update URL
 STATUS_TTL_SEC                      Number of seconds hours to keep job status
+STORE_HTTP_REQUESTS                 Boolean; should all http traffic be logged? Defaults to true.
 SURF_CONEXT_CLIENT_ID               SurfCONEXT client id for Mapper service
 SURF_CONEXT_CLIENT_SECRET           SurfCONEXT client secret for Mapper service
 SURF_CONEXT_INTROSPECTION_ENDPOINT  SurfCONEXT introspection endpoint

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/jomco/eduhub-rio-mapper"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[org.clojure/clojure "1.11.2"]
+  :dependencies [[org.clojure/clojure "1.11.3"]
                  [org.clojure/core.async "1.6.681"]
                  [org.clojure/core.memoize "1.1.266"]
                  [com.velisco/strgen "0.2.5" :exclusions [org.clojure/clojurescript]]
@@ -19,7 +19,7 @@
                  [nl.jomco/clj-http-status-codes "0.1"]
 
                  ;; state
-                 [com.taoensso/carmine "3.3.2"]
+                 [com.taoensso/carmine "3.4.1" :exclusions [org.clojure/tools.reader]]
 
                  ;; CLI
                  [nl.jomco/envopts "0.0.4"]

--- a/src/nl/surf/eduhub_rio_mapper/cli_commands.clj
+++ b/src/nl/surf/eduhub_rio_mapper/cli_commands.clj
@@ -68,9 +68,11 @@
 
     ("show" "dry-run-upsert")
     (let [[client-info [type id]] (parse-client-info-args args clients)
-          request (merge client-info {::ooapi/id id ::ooapi/type type})
-          handler (if (= "show" command) ooapi-loader dry-run!)]
-      (handler request))
+          request (merge client-info {::ooapi/id id ::ooapi/type type})]
+      (if (= "show" command)
+        (-> (ooapi-loader request)
+            (clojure.data.json/pprint))
+        (dry-run! request)))
 
     "link"
     (let [[client-info [code type id]] (parse-client-info-args args clients)

--- a/src/nl/surf/eduhub_rio_mapper/cli_commands.clj
+++ b/src/nl/surf/eduhub_rio_mapper/cli_commands.clj
@@ -17,7 +17,8 @@
 ;; <https://www.gnu.org/licenses/>.
 
 (ns nl.surf.eduhub-rio-mapper.cli-commands
-  (:require [clojure.string :as str]
+  (:require [clojure.data.json :as json]
+            [clojure.string :as str]
             [nl.surf.eduhub-rio-mapper.clients-info :as clients-info]
             [nl.surf.eduhub-rio-mapper.endpoints.api :as api]
             [nl.surf.eduhub-rio-mapper.endpoints.worker-api :as worker-api]
@@ -71,7 +72,7 @@
           request (merge client-info {::ooapi/id id ::ooapi/type type})]
       (if (= "show" command)
         (-> (ooapi-loader request)
-            (clojure.data.json/pprint))
+            (json/pprint))
         (dry-run! request)))
 
     "link"

--- a/src/nl/surf/eduhub_rio_mapper/main.clj
+++ b/src/nl/surf/eduhub_rio_mapper/main.clj
@@ -50,8 +50,11 @@
       (if (string? result) (println result)
                            (pprint/pprint result))
 
-      ("dry-run-upsert" "show" "link")
+      ("dry-run-upsert" "link")
       (pprint/pprint result)
+
+      "show"
+      nil
 
       "resolve"
       (println result)


### PR DESCRIPTION
The order of two wrapper functions was switched in commit 077ebfe9, and that led to the callback-url
being added to the response after the enqueue action.

We should have an e2e test covering this. I've made a Trello ticket to that purpose.
