### PR TITLE
Truncate rio fields per rio max length

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/commands/dry_run.clj
+++ b/src/nl/surf/eduhub_rio_mapper/commands/dry_run.clj
@@ -79,7 +79,7 @@
     {:begindatum                    (:validFrom current-period),
      :naamLang                      (ooapi-utils/get-localized-value (:name current-period) dutch-locales),
      :naamKort                      (:abbreviation current-period),
-     :internationaleNaam            (ooapi-utils/get-localized-value (:name current-period)),
+     :internationaleNaam            (ooapi-utils/get-localized-value (:name current-period) []),
      :omschrijving                  (ooapi-utils/get-localized-value (:description current-period) dutch-locales),
      :eigenOpleidingseenheidSleutel (:educationSpecificationId eduspec)}))
 
@@ -98,7 +98,7 @@
                                        (ooapi-utils/get-localized-value dutch-locales))
      :eigenNaamInternationaal      (-> current-period
                                        :name
-                                       (ooapi-utils/get-localized-value))
+                                       (ooapi-utils/get-localized-value []))
      :eigenOmschrijving            (-> current-period
                                        :description
                                        (ooapi-utils/get-localized-value dutch-locales))

--- a/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
@@ -54,7 +54,7 @@
    "privateProgram" "aangebodenParticuliereOpleiding"})
 
 (def ^:private mapping-course-program->aangeboden-opleiding
-  {:buitenlandsePartner [:foreignPartners true]
+  {:buitenlandsePartner [#(ooapi-utils/truncate (:foreignPartners %) 250) true]
    :eersteInstroomDatum [:firstStartDate false]
    :onderwijsaanbiedercode [:educationOffererCode true]
    :onderwijslocatiecode [:educationLocationCode true]
@@ -67,7 +67,7 @@
    :deelnemersplaatsen :maxNumberStudents
    :einddatum :endDate
    :eindeAanmeldperiode :enrollEndDate
-   :toelichtingVereisteToestemming :explanationRequiredPermission})
+   :toelichtingVereisteToestemming #(-> % :explanationRequiredPermission (ooapi-utils/truncate 3000))})
 
 (defn- course-program-timeline-override-adapter
   [{:keys [name description validFrom abbreviation link consumers] :as _periode}]
@@ -76,14 +76,14 @@
     (fn [pk]
       (case pk
         :begindatum validFrom
-        :buitenlandsePartner foreignPartners
+        :buitenlandsePartner (ooapi-utils/truncate foreignPartners 250)
         :deficientie (rio-helper/ooapi-mapping "deficientie" deficiency)
-        :eigenNaamAangebodenOpleiding (ooapi-utils/get-localized-value name ["nl-NL" "nl"])
-        :eigenNaamInternationaal (ooapi-utils/get-localized-value-exclusive name ["en"])
-        :eigenNaamKort abbreviation
-        :eigenOmschrijving (ooapi-utils/get-localized-value description ["nl-NL" "nl"])
+        :eigenNaamAangebodenOpleiding (ooapi-utils/get-localized-value name ["nl-NL" "nl"] :maxlen 225)
+        :eigenNaamInternationaal (ooapi-utils/get-localized-value-exclusive name ["en"] :maxlen 225)
+        :eigenNaamKort (ooapi-utils/truncate abbreviation 40)
+        :eigenOmschrijving (ooapi-utils/get-localized-value description ["nl-NL" "nl"] :maxlen 3000)
         :eisenWerkzaamheden (rio-helper/ooapi-mapping "eisenWerkzaamheden" requirementsActivities)
-        :internationaleNaamDuits (ooapi-utils/get-localized-value-exclusive name ["de"])
+        :internationaleNaamDuits (ooapi-utils/get-localized-value-exclusive name ["de"] :maxlen 225)
         :propedeutischeFase (rio-helper/ooapi-mapping "propedeutischeFase" propaedeuticPhase)
         :samenwerkendeOnderwijsaanbiedercode jointPartnerCodes
         :studiekeuzecheck (rio-helper/ooapi-mapping "studiekeuzecheck" studyChoiceCheck)

--- a/src/nl/surf/eduhub_rio_mapper/rio/opleidingseenheid.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/opleidingseenheid.clj
@@ -42,10 +42,10 @@
   (fn [pk]
     (case pk
       :begindatum validFrom
-      :internationaleNaam (ooapi-utils/get-localized-value-exclusive name ["en"])
-      :naamKort abbreviation
-      :naamLang (ooapi-utils/get-localized-value name ["nl-NL" "nl"])
-      :omschrijving (ooapi-utils/get-localized-value description ["nl-NL" "nl"])
+      :internationaleNaam (ooapi-utils/get-localized-value-exclusive name ["en"] :maxlen 225)
+      :naamKort (ooapi-utils/truncate abbreviation 40)
+      :naamLang (ooapi-utils/get-localized-value name ["nl-NL" "nl"] :maxlen 225)
+      :omschrijving (ooapi-utils/get-localized-value description ["nl-NL" "nl"] :maxlen 3000)
       :studielast (if (= "VARIANT" (soort-mapping eduspec)) nil (:value studyLoad))
       :studielasteenheid (rio-helper/ooapi-mapping "studielasteenheid" (:studyLoadUnit studyLoad))
       :waardedocumentsoort (rio-helper/ooapi-mapping "waardedocumentsoort" formalDocument))))

--- a/test/nl/surf/eduhub_rio_mapper/rio_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/rio_test.clj
@@ -33,8 +33,7 @@
             [nl.surf.eduhub-rio-mapper.utils.keystore :as keystore]
             [nl.surf.eduhub-rio-mapper.utils.soap :as soap]
             [nl.surf.eduhub-rio-mapper.utils.xml-utils :as xml-utils])
-  (:import clojure.lang.ExceptionInfo
-           java.io.PushbackReader))
+  (:import java.io.PushbackReader))
 
 (deftest canonicalization-and-digestion
   (let [canonicalizer (fn [id] (str "<wsa:Action "
@@ -101,17 +100,6 @@
     {::ooapi/id "30010000-0000-0000-0000-000000000000"
      ::ooapi/type "course"
      :client-id "rio-mapper-dev.jomco.nl"}))
-
-;; eigenNaamInternationaal max 225 chars
-(deftest test-and-validate-program-4-invalid
-  (let [request (test-handler {::ooapi/id "29990000-0000-0000-0000-000000000000"
-                               ::ooapi/type "program"
-                               :client-id "rio-mapper-dev.jomco.nl"})]
-    (is (thrown? ExceptionInfo
-                 (-> request
-                     prep-body
-                     (soap/guard-valid-sexp mutator/validator)))
-        "guard should throw an exception")))
 
 (defn collect-paths
   "If leaf-node, add current path (and node if include-leaves is true) to acc.


### PR DESCRIPTION
Implemented due to comment by Herman van Dompselaar:

ik lees toevallig even mee. Je zou nog kunnen overwegen om de inhoud na 1000 karakters af te kappen voor rio. Want het is wel geldige ooapi. Als het dan niet allemaal in rio komt is blijkbaar geen probleem. Of dan moeten ze het veld inkorten. Maar zo hebben instellingen wel de mogelijkheid meer karakters te gebruiken in ooapi die voor andere toepassingen wel relevant zijn.
