### PR TITLE
Upgrade docker container to openjdk 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM clojure:temurin-11-lein-2.9.10-alpine as builder
+FROM clojure:temurin-17-lein-2.11.2-alpine as builder
 
 RUN mkdir /app
 WORKDIR /app
 COPY . /app/
 RUN lein uberjar
 
-FROM gcr.io/distroless/java:11
+FROM gcr.io/distroless/java17-debian12
 COPY --from=builder /app/target/eduhub-rio-mapper.jar /eduhub-rio-mapper.jar
 
 ENTRYPOINT ["java", "-jar", "/eduhub-rio-mapper.jar"]


### PR DESCRIPTION
To support `UseContainerSupport` (set by default) and reliably use
`MaxRAMPercentage`.

When running in a (docker) container use the memory limit of the runtime
environment / cgroup and set environment variable `JAVA_TOOL_OPTIONS` to
`-XX:MaxRAMPercentage=75` to make sure the JVM uses at least 75% of the
allocated memory.  Note that 75% is a safe setting.