### PR TITLE
Add timestamps to status

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/endpoints/api.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/api.clj
@@ -39,15 +39,12 @@
             [ring.middleware.json :refer [wrap-json-response]]
             [ring.util.response :as response])
   (:import [java.net MalformedURLException URL]
-           java.util.UUID
-           [java.time LocalDateTime]
-           [java.time.format DateTimeFormatter]))
+           [java.time Instant]
+           java.util.UUID))
 
 (def server-stopping (atom false))
 
 (def nr-active-requests (atom 0))
-
-(def datetime-formatter (DateTimeFormatter/ofPattern "yyyy-MM-dd HH:mm:ss"))
 
 (defn wrap-server-status [app]
   (fn [req]
@@ -66,7 +63,7 @@
       (if job
         (let [token (UUID/randomUUID)]
           (with-mdc {:token token}
-            (enqueue-fn (assoc job :token token :created-at (.format datetime-formatter (LocalDateTime/now)))))
+                    (enqueue-fn (assoc job :token token :created-at (str (Instant/now)))))
           (assoc res :body {:token token}))
         res))))
 

--- a/src/nl/surf/eduhub_rio_mapper/endpoints/api.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/api.clj
@@ -63,6 +63,7 @@
       (if job
         (let [token (UUID/randomUUID)]
           (with-mdc {:token token}
+                    ; store created-at in job itself as soon as it is created
                     (enqueue-fn (assoc job :token token :created-at (str (Instant/now)))))
           (assoc res :body {:token token}))
         res))))

--- a/src/nl/surf/eduhub_rio_mapper/endpoints/api.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/api.clj
@@ -39,11 +39,15 @@
             [ring.middleware.json :refer [wrap-json-response]]
             [ring.util.response :as response])
   (:import [java.net MalformedURLException URL]
-           java.util.UUID))
+           java.util.UUID
+           [java.time LocalDateTime]
+           [java.time.format DateTimeFormatter]))
 
 (def server-stopping (atom false))
 
 (def nr-active-requests (atom 0))
+
+(def datetime-formatter (DateTimeFormatter/ofPattern "yyyy-MM-dd HH:mm:ss"))
 
 (defn wrap-server-status [app]
   (fn [req]
@@ -62,7 +66,7 @@
       (if job
         (let [token (UUID/randomUUID)]
           (with-mdc {:token token}
-            (enqueue-fn (assoc job :token token)))
+            (enqueue-fn (assoc job :token token :created-at (.format datetime-formatter (LocalDateTime/now)))))
           (assoc res :body {:token token}))
         res))))
 

--- a/src/nl/surf/eduhub_rio_mapper/endpoints/status.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/status.clj
@@ -28,8 +28,7 @@
             [nl.surf.eduhub-rio-mapper.utils.http-utils :as http-utils]
             [nl.surf.eduhub-rio-mapper.utils.logging :as logging]
             [nl.surf.eduhub-rio-mapper.utils.redis :as redis])
-  (:import [java.time LocalDateTime]
-           [java.time.format DateTimeFormatter]))
+  (:import [java.time Instant]))
 
 (defn- status-key
   [{:keys [redis-key-prefix]
@@ -100,8 +99,6 @@
   (and (errors? x)
        (some-> x :errors :retryable? boolean)))
 
-(def datetime-formatter (DateTimeFormatter/ofPattern "yyyy-MM-dd HH:mm:ss"))
-
 (defn make-set-status-fn [config]
   (fn [{::job/keys [callback-url] :keys [token action created-at] ::ooapi/keys [id type] :as job}
        status & [data]]
@@ -114,7 +111,7 @@
                                          :resource   (str type "/" id)}
 
                                         (#{:done :error :time-out} status)
-                                        (assoc :finished-at (.format datetime-formatter (LocalDateTime/now)))
+                                        (assoc :finished-at (str (Instant/now)))
 
                                         (and (= :done status)
                                              opleidingseenheidcode)

--- a/src/nl/surf/eduhub_rio_mapper/endpoints/status.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/status.clj
@@ -27,7 +27,9 @@
             [nl.surf.eduhub-rio-mapper.specs.rio :as rio]
             [nl.surf.eduhub-rio-mapper.utils.http-utils :as http-utils]
             [nl.surf.eduhub-rio-mapper.utils.logging :as logging]
-            [nl.surf.eduhub-rio-mapper.utils.redis :as redis]))
+            [nl.surf.eduhub-rio-mapper.utils.redis :as redis])
+  (:import [java.time LocalDateTime]
+           [java.time.format DateTimeFormatter]))
 
 (defn- status-key
   [{:keys [redis-key-prefix]
@@ -97,6 +99,8 @@
   [x]
   (and (errors? x)
        (some-> x :errors :retryable? boolean)))
+
+(def datetime-formatter (DateTimeFormatter/ofPattern "yyyy-MM-dd HH:mm:ss"))
 
 (defn make-set-status-fn [config]
   (fn [{::job/keys [callback-url] :keys [token action] ::ooapi/keys [id type] :as job}

--- a/src/nl/surf/eduhub_rio_mapper/worker.clj
+++ b/src/nl/surf/eduhub_rio_mapper/worker.clj
@@ -319,7 +319,7 @@
            (if (ex-util/backtrace-matches-regex? ex #"carmine")
              (RuntimeException. "Redis is not available")
              ex))
-         (catch Exception ex
+         (catch Throwable ex
            ex)
          (finally
            (reset! worker-busy false))))]))

--- a/test/nl/surf/eduhub_rio_mapper/endpoints/api_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/endpoints/api_test.clj
@@ -267,12 +267,14 @@
 
     (status-set! {:token       "test-pending"
                   :action      "upsert"
+                  :created-at  "2024-08-28 12:39:07"
                   ::ooapi/type "test"
                   ::ooapi/id   "314"}
                  :pending)
 
     (status-set! {:token       "test-error"
                   :action      "link"
+                  :created-at  "2024-08-28 12:39:07"
                   ::ooapi/type "test"
                   ::ooapi/id   "3141"}
                  :error
@@ -283,6 +285,7 @@
 
     (status-set! {:token       "test-done"
                   :action      "delete"
+                  :created-at  "2024-08-28 12:39:07"
                   ::ooapi/type "test"
                   ::ooapi/id   "31415"}
                  :done
@@ -312,8 +315,10 @@
             :body   {:status   :pending
                      :action   "upsert"
                      :token    "test-pending"
+                     :created-at true
                      :resource "test/314"}}
-           (app {:token "test-pending"})))
+           (cond-> (app {:token "test-pending"})
+                   :created-at (assoc-in [:body :created-at] true))))
 
     ;; test done status
     (is (= {:token  "test-done"
@@ -322,8 +327,12 @@
                      :action     "delete"
                      :token      "test-done"
                      :resource   "test/31415"
+                     :created-at true
+                     :finished-at true
                      :attributes {:opleidingseenheidcode "code"}}}
-           (app {:token "test-done"})))
+           (cond-> (app {:token "test-done"})
+                   :created-at (assoc-in [:body :created-at] true)
+                   :finished-at (assoc-in [:body :finished-at] true))))
 
     ;; test error status
     (is (= {:token  "test-error"
@@ -332,9 +341,13 @@
                      :token    "test-error"
                      :action   "link"
                      :resource "test/3141"
+                     :created-at true
+                     :finished-at true
                      :phase    "middle"
                      :message  "error"}}
-           (app {:token "test-error"})))
+           (cond-> (app {:token "test-error"})
+                   :created-at (assoc-in [:body :created-at] true)
+                   :finished-at (assoc-in [:body :finished-at] true))))
 
     (status/purge! config)))
 

--- a/test/nl/surf/eduhub_rio_mapper/endpoints/api_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/endpoints/api_test.clj
@@ -267,14 +267,14 @@
 
     (status-set! {:token       "test-pending"
                   :action      "upsert"
-                  :created-at  "2024-08-28 12:39:07"
+                  :created-at  "2024-08-30T08:41:34.929378Z"
                   ::ooapi/type "test"
                   ::ooapi/id   "314"}
                  :pending)
 
     (status-set! {:token       "test-error"
                   :action      "link"
-                  :created-at  "2024-08-28 12:39:07"
+                  :created-at  "2024-08-30T08:41:34.929378Z"
                   ::ooapi/type "test"
                   ::ooapi/id   "3141"}
                  :error
@@ -285,7 +285,7 @@
 
     (status-set! {:token       "test-done"
                   :action      "delete"
-                  :created-at  "2024-08-28 12:39:07"
+                  :created-at  "2024-08-30T08:41:34.929378Z"
                   ::ooapi/type "test"
                   ::ooapi/id   "31415"}
                  :done

--- a/test/nl/surf/eduhub_rio_mapper/endpoints/api_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/endpoints/api_test.clj
@@ -268,6 +268,7 @@
     (status-set! {:token       "test-pending"
                   :action      "upsert"
                   :created-at  "2024-08-30T08:41:34.929378Z"
+                  :started-at  nil
                   ::ooapi/type "test"
                   ::ooapi/id   "314"}
                  :pending)
@@ -275,6 +276,7 @@
     (status-set! {:token       "test-error"
                   :action      "link"
                   :created-at  "2024-08-30T08:41:34.929378Z"
+                  :started-at  "2024-08-30T08:41:34.929378Z"
                   ::ooapi/type "test"
                   ::ooapi/id   "3141"}
                  :error
@@ -286,6 +288,7 @@
     (status-set! {:token       "test-done"
                   :action      "delete"
                   :created-at  "2024-08-30T08:41:34.929378Z"
+                  :started-at  "2024-08-30T08:41:34.929378Z"
                   ::ooapi/type "test"
                   ::ooapi/id   "31415"}
                  :done
@@ -316,6 +319,7 @@
                      :action   "upsert"
                      :token    "test-pending"
                      :created-at true
+                     :started-at nil
                      :resource "test/314"}}
            (cond-> (app {:token "test-pending"})
                    :created-at (assoc-in [:body :created-at] true))))
@@ -328,6 +332,7 @@
                      :token      "test-done"
                      :resource   "test/31415"
                      :created-at true
+                     :started-at  "2024-08-30T08:41:34.929378Z"
                      :finished-at true
                      :attributes {:opleidingseenheidcode "code"}}}
            (cond-> (app {:token "test-done"})
@@ -342,6 +347,7 @@
                      :action   "link"
                      :resource "test/3141"
                      :created-at true
+                     :started-at  "2024-08-30T08:41:34.929378Z"
                      :finished-at true
                      :phase    "middle"
                      :message  "error"}}

--- a/test/nl/surf/eduhub_rio_mapper/endpoints/api_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/endpoints/api_test.clj
@@ -230,9 +230,11 @@
       (is (-> res :body :token)
           "token returned")
 
-      (is (= {:test "dummy"}
-             (-> @queue-atom first (dissoc :token)))
-          "job queued")
+      (let [job-result (-> @queue-atom first (dissoc :token))]
+        (is (= [:test :created-at] (keys job-result)))
+        (is (= {:test "dummy"}
+               (dissoc job-result :created-at))
+            "job queued"))
 
       (is (-> @queue-atom first :token)
           "job has token")

--- a/test/nl/surf/eduhub_rio_mapper/job_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/job_test.clj
@@ -61,7 +61,7 @@
                                   :action            "delete"
                                   ::ooapi/type       "course"
                                   ::ooapi/id         "123123"
-                                  :created-at        "2024-08-28 12:39:07"
+                                  :created-at        "2024-08-30T08:41:34.929378Z"
                                   :token             "12345"}
           mock-webhook           (fn mock-webhook [req]
                                    (reset! last-seen-request-atom req)
@@ -76,7 +76,7 @@
                   :action        "delete"
                   :resource      "course/123123"
                   :attributes    {:opleidingseenheidcode "123"}
-                  :created-at    "2024-08-28 12:39:07"
+                  :created-at    "2024-08-30T08:41:34.929378Z"
                   :token         "12345"}
                  (dissoc (json/read-str (:body req) {:key-fn keyword}) :finished-at)))
           (is (= (:url req) "https://github.com/")))))))

--- a/test/nl/surf/eduhub_rio_mapper/job_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/job_test.clj
@@ -62,6 +62,7 @@
                                   ::ooapi/type       "course"
                                   ::ooapi/id         "123123"
                                   :created-at        "2024-08-30T08:41:34.929378Z"
+                                  :started-at        "2024-08-30T08:41:34.929378Z"
                                   :token             "12345"}
           mock-webhook           (fn mock-webhook [req]
                                    (reset! last-seen-request-atom req)
@@ -77,6 +78,7 @@
                   :resource      "course/123123"
                   :attributes    {:opleidingseenheidcode "123"}
                   :created-at    "2024-08-30T08:41:34.929378Z"
+                  :started-at    "2024-08-30T08:41:34.929378Z"
                   :token         "12345"}
                  (dissoc (json/read-str (:body req) {:key-fn keyword}) :finished-at)))
           (is (= (:url req) "https://github.com/")))))))

--- a/test/nl/surf/eduhub_rio_mapper/job_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/job_test.clj
@@ -61,6 +61,7 @@
                                   :action            "delete"
                                   ::ooapi/type       "course"
                                   ::ooapi/id         "123123"
+                                  :created-at        "2024-08-28 12:39:07"
                                   :token             "12345"}
           mock-webhook           (fn mock-webhook [req]
                                    (reset! last-seen-request-atom req)
@@ -75,6 +76,7 @@
                   :action        "delete"
                   :resource      "course/123123"
                   :attributes    {:opleidingseenheidcode "123"}
+                  :created-at    "2024-08-28 12:39:07"
                   :token         "12345"}
-                 (json/read-str (:body req) {:key-fn keyword})))
+                 (dissoc (json/read-str (:body req) {:key-fn keyword}) :finished-at)))
           (is (= (:url req) "https://github.com/")))))))

--- a/test/nl/surf/eduhub_rio_mapper/worker_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/worker_test.clj
@@ -81,7 +81,7 @@
                           (assoc-in [:worker :max-retries] max-retries)
                           (assoc-in [:worker :run-job-fn]
                                     (fn [job]
-                                      (reset! last-seen-job job)
+                                      (reset! last-seen-job (dissoc job :started-at))
                                       :from-job))
                           (assoc-in [:worker :retryable-fn]
                                     (fn [result]
@@ -109,7 +109,7 @@
                           (assoc-in [:worker :max-retries] max-retries)
                           (assoc-in [:worker :run-job-fn]
                                     (fn [job]
-                                      (reset! last-seen-job job)
+                                      (reset! last-seen-job (dissoc job :started-at))
                                       (::worker/retries job)))
                           (assoc-in [:worker :retryable-fn]
                                     (fn [result]
@@ -137,7 +137,7 @@
                           (assoc-in [:worker :retry-wait-ms] retry-wait-ms)
                           (assoc-in [:worker :run-job-fn]
                                     (fn [job]
-                                      (reset! last-seen-job job)
+                                      (reset! last-seen-job (dissoc job :started-at))
                                       (::worker/retries job)))
                           (assoc-in [:worker :retryable-fn]
                                     (fn [result]
@@ -170,9 +170,9 @@
                                (assoc-in [:worker :run-job-fn] identity)
                                (assoc-in [:worker :set-status-fn]
                                          (fn [job status & [data]]
-                                           (reset! last-seen-status {:job    job
+                                           (reset! last-seen-status {:job    (dissoc job :started-at)
                                                                      :status status
-                                                                     :data   data}))))]
+                                                                     :data   (dissoc data :started-at)}))))]
       (worker/purge! config)
 
       ;; queue a successful job


### PR DESCRIPTION
Add created-at and finished-at timestamps to status.
created-at is set when the job is initially created, finished at is set when the status moves to done, error or timeout.
