### PR TITLE
Fix running e2e test on github actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,8 +27,7 @@ jobs:
 
     - name: Run tests
       env:
-        API_HOST: ${{ secrets.API_HOST }}
-        API_PORT: ${{ secrets.API_PORT }}
+        API_PORT: 8080
         CLIENTS_INFO_PATH: ${{ secrets.CLIENTS_INFO_PATH }}
         CLIENT_ID: ${{ secrets.CLIENT_ID }}
         CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
@@ -54,7 +53,6 @@ jobs:
         TOKEN_ENDPOINT: ${{ secrets.TOKEN_ENDPOINT }}
         TRUSTSTORE: truststore.jks
         TRUSTSTORE_PASSWORD: ${{ secrets.TRUSTSTORE_PASSWORD }}
-        WORKER_API_HOST: ${{ secrets.WORKER_API_HOST }}
-        WORKER_API_PORT: ${{ secrets.WORKER_API_PORT }}
+        WORKER_API_PORT: 8081
 
       run: lein test :e2e


### PR DESCRIPTION
No need to set `API_HOST` or `WORKER_API_HOST` and keep `API_PORT` and `WORKER_API_PORT` in secrets.  The later are currently missing or set to some bad value:

  https://github.com/SURFnet/eduhub-rio-mapper/actions/runs/11667613166/job/32485328704#step:7:100