### PR TITLE
Fixed RIO queue test

### DIFF
--- a/.github/workflows/test-rio.yml
+++ b/.github/workflows/test-rio.yml
@@ -64,26 +64,28 @@ jobs:
           TRUSTSTORE_PASSWORD: ${{ secrets.TRUSTSTORE_PASSWORD }}
         id: test_rio
         run: |
+          set +e
           lein mapper test-rio rio-mapper-dev.jomco.nl
           echo "ERROR_STATUS=$?" >> "$GITHUB_OUTPUT"
+          set -e
         continue-on-error: true
       - name: Notify ok only if previous run failed.
         env:
           SLACK_URL: ${{ secrets.SLACK_URL }}
-        if: ${{ steps.test_rio.outputs.ERROR_STATUS == 0 && steps.last_status.outputs.last_status != 'success' }}
+        if: ${{ steps.test_rio.outputs.ERROR_STATUS == '0' && steps.last_status.outputs.last_status != 'success' }}
         run: |
           curl -q -H "Content-Type: application/json" -X POST -d '{"text": "RIO Queue is finally UP"}' $SLACK_URL
       - name: Notify queue down
         env:
           SLACK_URL: ${{ secrets.SLACK_URL }}
-        if: ${{ steps.test_rio.outputs.ERROR_STATUS == 255 }}
+        if: ${{ steps.test_rio.outputs.ERROR_STATUS == '255' }}
         run: |
           curl -q -H "Content-Type: application/json" -X POST -d '{"text": "RIO Queue is DOWN"}' $SLACK_URL
           exit 1
       - name: Notify error
         env:
           SLACK_URL: ${{ secrets.SLACK_URL }}
-        if: ${{ steps.test_rio.outputs.ERROR_STATUS == 254 }}
+        if: ${{ steps.test_rio.outputs.ERROR_STATUS == '254' }}
         run: |
           curl -q -H "Content-Type: application/json" -X POST -d '{"text": "Error while checking RIO Queue"}' $SLACK_URL
           exit 1


### PR DESCRIPTION
Deze github workflow heeft nooit gewerkt. De output variabelen zijn strings, en zonder `set +e` stopt het script meteen wanneer leiningen een nonzero error code teruggeeft.