### PR TITLE
Joint degree functionaliteit

### DIFF
--- a/src/nl/surf/eduhub_rio_mapper/commands/processing.clj
+++ b/src/nl/surf/eduhub_rio_mapper/commands/processing.clj
@@ -23,6 +23,7 @@
     [nl.jomco.http-status-codes :as http-status]
     [nl.surf.eduhub-rio-mapper.commands.dry-run :as dry-run]
     [nl.surf.eduhub-rio-mapper.commands.link :as link]
+    [nl.surf.eduhub-rio-mapper.ooapi.base :as ooapi-base]
     [nl.surf.eduhub-rio-mapper.ooapi.loader :as ooapi.loader]
     [nl.surf.eduhub-rio-mapper.rio.loader :as rio.loader]
     [nl.surf.eduhub-rio-mapper.rio.mutator :as mutator]
@@ -63,10 +64,14 @@
         (ooapi.loader/load-entities validating-loader request)))))
 
 (defn- make-updater-resolve-phase [{:keys [resolver]}]
-  (fn resolve-phase [{::ooapi/keys [type id] :keys [institution-oin action] ::rio/keys [opleidingscode] :as request}]
+  (fn resolve-phase [{:keys [institution-oin action]
+                      ::ooapi/keys [type id entity]
+                      ::rio/keys [opleidingscode] :as request}]
     {:pre [institution-oin]}
     (let [resolve-eduspec (= type "education-specification")
-          edu-id          (updated-handler/education-specification-id request)
+          edu-id          (if (= type "education-specification")
+                            id
+                            (ooapi-base/education-specification-id entity))
           oe-code         (or opleidingscode
                               (resolver "education-specification" edu-id institution-oin))
           ao-code         (when-not resolve-eduspec (resolver type id institution-oin))]

--- a/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
+++ b/src/nl/surf/eduhub_rio_mapper/ooapi/loader.clj
@@ -186,11 +186,11 @@
       (validate-entity entity ::program/ProgramType "ProgramType")
       (validate-entity rio-consumer ::program/ProgramConsumerType "ProgramConsumerType"))
     (cond-> request
-            true
-            (assoc
-              ::ooapi/entity (assoc entity :offerings offerings)
-              ::ooapi/education-specification-type eduspec-type)
-
             joint-program?
             (assoc
-              ::rio/opleidingscode (:educationUnitCode rio-consumer)))))
+              ::rio/opleidingscode (:educationUnitCode rio-consumer))
+
+            :always
+            (assoc
+              ::ooapi/entity (assoc entity :offerings offerings)
+              ::ooapi/education-specification-type eduspec-type))))

--- a/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
@@ -58,7 +58,6 @@
    :eersteInstroomDatum [:firstStartDate false]
    :onderwijsaanbiedercode [:educationOffererCode true]
    :onderwijslocatiecode [:educationLocationCode true]
-   :opleidingseenheidSleutel [::rio/opleidingscode false]
    :toestemmingDeelnameSTAP [:consentParticipationSTAP true]
    :voertaal [:teachingLanguage false]})
 
@@ -144,36 +143,35 @@
                              :validTo   (:validTo %))
                           timelineOverrides)]
     (fn [k] {:pre [(keyword? k)]}
-      (if (= k :opleidingseenheidSleutel)
-        opleidingscode
-        (if-let [[translation consumer] (mapping-course-program->aangeboden-opleiding k)]
-          (if (ooapi-mapping? (name k))
-            (rio-helper/ooapi-mapping (name k) (translation (if consumer rio-consumer course-program)))
-            (translation (if consumer rio-consumer course-program)))
-          (case k
-            ;; Required field. If found in the resolve phase, will be added to the entity under the rioCode key,
-            ;; otherwise use the eigen sleutel value (an UUID).
-            :aangebodenOpleidingCode (or rioCode id)
-            ;; See opleidingseenheid for explanation of timelineOverrides and periods.
-            :begindatum (first (sort (conj (map :validFrom timelineOverrides) validFrom)))
-            :einddatum (last (sort (conj (map :validTo timelineOverrides) validTo)))
-            :ISCED (rio-helper/narrow-isced fieldsOfStudy)
-            :afwijkendeOpleidingsduur (when duration-map {:opleidingsduurEenheid (:eenheid duration-map)
-                                                          :opleidingsduurOmvang (:omvang duration-map)})
-            :niveau (rio-helper/level-sector-mapping level sector)
-            :vorm (rio-helper/ooapi-mapping "vorm" modeOfStudy)
+      (if-let [[translation consumer] (mapping-course-program->aangeboden-opleiding k)]
+        (if (ooapi-mapping? (name k))
+          (rio-helper/ooapi-mapping (name k) (translation (if consumer rio-consumer course-program)))
+          (translation (if consumer rio-consumer course-program)))
+        (case k
+          :opleidingseenheidSleutel opleidingscode
+          ;; Required field. If found in the resolve phase, will be added to the entity under the rioCode key,
+          ;; otherwise use the eigen sleutel value (an UUID).
+          :aangebodenOpleidingCode (or rioCode id)
+          ;; See opleidingseenheid for explanation of timelineOverrides and periods.
+          :begindatum (first (sort (conj (map :validFrom timelineOverrides) validFrom)))
+          :einddatum (last (sort (conj (map :validTo timelineOverrides) validTo)))
+          :ISCED (rio-helper/narrow-isced fieldsOfStudy)
+          :afwijkendeOpleidingsduur (when duration-map {:opleidingsduurEenheid (:eenheid duration-map)
+                                                        :opleidingsduurOmvang  (:omvang duration-map)})
+          :niveau (rio-helper/level-sector-mapping level sector)
+          :vorm (rio-helper/ooapi-mapping "vorm" modeOfStudy)
 
-            :cohorten (mapv #(course-program-offering-adapter %)
-                            offerings)
+          :cohorten (mapv #(course-program-offering-adapter %)
+                          offerings)
 
-            ;; See opleidingseenheid for explanation of timelineOverrides and periods.
-            :periodes (->> (conj periods course-program)
-                           (mapv #(course-program-timeline-override-adapter %)))
+          ;; See opleidingseenheid for explanation of timelineOverrides and periods.
+          :periodes (->> (conj periods course-program)
+                         (mapv #(course-program-timeline-override-adapter %)))
 
-            ;; These are in the xsd but ignored by us
-            :eigenAangebodenOpleidingSleutel (some-> id str/lower-case) ;; resolve to the ooapi id
-            :opleidingserkenningSleutel nil
-            :voVakerkenningSleutel nil))))))
+          ;; These are in the xsd but ignored by us
+          :eigenAangebodenOpleidingSleutel (some-> id str/lower-case) ;; resolve to the ooapi id
+          :opleidingserkenningSleutel nil
+          :voVakerkenningSleutel nil)))))
 
 (defn ->aangeboden-opleiding
   "Converts a program or course into the right kind of AangebodenOpleiding."

--- a/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
+++ b/src/nl/surf/eduhub_rio_mapper/rio/aangeboden_opleiding.clj
@@ -19,7 +19,6 @@
 (ns nl.surf.eduhub-rio-mapper.rio.aangeboden-opleiding
   (:require [clojure.string :as str]
             [nl.surf.eduhub-rio-mapper.rio.helper :as rio-helper]
-            [nl.surf.eduhub-rio-mapper.specs.rio :as rio]
             [nl.surf.eduhub-rio-mapper.utils.ooapi :as ooapi-utils])
   (:import [java.time Period Duration]))
 
@@ -176,6 +175,7 @@
 (defn ->aangeboden-opleiding
   "Converts a program or course into the right kind of AangebodenOpleiding."
   [course-program ooapi-type opleidingscode education-specification-type]
+  {:pre [(string? education-specification-type)]}
   (-> (course-program-adapter course-program opleidingscode ooapi-type)
       rio-helper/wrapper-periodes-cohorten
       (rio-helper/->xml (education-specification-type-mapping education-specification-type))))

--- a/src/nl/surf/eduhub_rio_mapper/specs/program.clj
+++ b/src/nl/surf/eduhub_rio_mapper/specs/program.clj
@@ -20,7 +20,8 @@
   (:require [clojure.spec.alpha :as s]
             [nl.surf.eduhub-rio-mapper.ooapi.enums :as enums]
             [nl.surf.eduhub-rio-mapper.re-spec :refer [re-spec text-spec]]
-            [nl.surf.eduhub-rio-mapper.specs.common :as common]))
+            [nl.surf.eduhub-rio-mapper.specs.common :as common]
+            [nl.surf.eduhub-rio-mapper.specs.rio :as rio]))
 
 (s/def ::abbreviation
   (text-spec 1 40))
@@ -32,6 +33,8 @@
 (s/def ::description ::common/LongLanguageTypedStrings)
 (s/def ::educationLocationCode string?)
 (s/def ::educationSpecification ::common/uuid)
+(s/def ::educationUnitCode ::rio/OpleidingsEenheidID-v01)
+(s/def ::jointProgram boolean?)
 (s/def ::firstStartDate ::common/date)
 (s/def ::foreignPartner string?)
 (s/def ::foreignPartners (s/coll-of ::foreignPartner))
@@ -82,13 +85,13 @@
 (s/def ::program
   (s/keys :req-un [::programId
                    ::consumers
-                   ::educationSpecification
                    ::name
                    ::validFrom]
           :opt-un [::abbreviation
                    ::children
                    ::description
                    ::common/duration
+                   ::educationSpecification
                    ::link
                    ::modeOfStudy
                    ::parent
@@ -104,4 +107,6 @@
 
 (s/def ::ProgramConsumerType
   (s/keys :req-un [::propaedeuticPhase
-                   ::studyChoiceCheck]))
+                   ::studyChoiceCheck]
+          :opt-un [::educationUnitCode
+                   ::jointProgram]))

--- a/test/nl/surf/eduhub_rio_mapper/mapper_integration_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/mapper_integration_test.clj
@@ -49,31 +49,21 @@
       ("course" "program") (load-json program-course)
       (load-json offerings))))
 
-;; resolver takes sender-oin and ooapi-id and returns code
-;; ooapi-loader takes request with type and id and returns request
-;; mutator takes {:keys [action sender-oin rio-sexp]} returns json
-(defn- mock-handle-updated [ooapi-loader]
-  (as-> updated-handler/update-mutation $
-        (helper/wrap-resolver $ (fn rio-resolver [ootype _id _oin] (if (= ootype "education-specification")
-                                                                              rio-opleidingsid
-                                                                              "12345678-9abc-def0-1234-56789abcdef0")))
-        (helper/wrap-load-entities $ ooapi-loader)))
+(defn mock-ooapi-loader-simple [{:keys [eduspec program-course offerings]} ooapi-type]
+  (case ooapi-type
+    "education-specification" (load-json eduspec)
+    ("course" "program") (load-json program-course)
+    (load-json offerings)))
 
-;; resolver takes sender-oin and ooapi-id and returns code
-;; mutator takes {:keys [action sender-oin rio-sexp]} returns json
-(defn- mock-handle-deleted [id type institution-oin]
-  (let [handle-deleted (as-> updated-handler/deletion-mutation $
-                             (helper/wrap-resolver $ (fn rio-resolver [ootype _id _sender-oin] (if (= ootype "education-specification")
-                                                                                                          rio-opleidingsid
-                                                                                                          "12345678-9abc-def0-1234-56789abcdef0"))))]
-    (handle-deleted {::ooapi/id       id
-                     ::ooapi/type     type
-                     :institution-oin institution-oin})))
+(defn- test-resolver [ootype]
+  (if (= ootype "education-specification")
+    rio-opleidingsid
+    "12345678-9abc-def0-1234-56789abcdef0"))
 
 (defn- simulate-upsert [ooapi-loader xml-response ooapi-type]
   {:pre [(some? xml-response)]}
   (binding [client/request (constantly {:status 200 :body xml-response})]
-    (let [handle-updated (mock-handle-updated ooapi-loader)
+    (let [handle-updated #(helper/test-handler % test-resolver ooapi-loader)
           mutation       (handle-updated {::ooapi/id ooapi-id
                                           ::ooapi/type ooapi-type
                                           :institution-oin institution-oin
@@ -84,42 +74,45 @@
 (defn- simulate-delete [ooapi-type xml-response]
   {:pre [(some? xml-response)]}
   (binding [client/request (constantly {:status 200 :body xml-response})]
-    (let [mutation (mock-handle-deleted ooapi-id ooapi-type institution-oin)]
+    (let [mutation (updated-handler/deletion-mutation (helper/test-resolve-request {::ooapi/id       ooapi-id
+                                                                                    ::ooapi/type     ooapi-type
+                                                                                    :institution-oin institution-oin}
+                                                                                   test-resolver))]
       (mutator/mutate! mutation (:rio-config config)))))
 
+(def eduspec-req-0 {:eduspec        "fixtures/ooapi/integration-eduspec-0.json"
+                    :program-course nil
+                    :offerings      nil})
+
+(def program-req-0 {:program-course "fixtures/ooapi/integration-program-0.json"
+                    :offerings      "fixtures/ooapi/integration-program-offerings-0.json"})
+
 (deftest test-handle-updated-eduspec-0
-  (let [ooapi-loader (mock-ooapi-loader {:eduspec        "fixtures/ooapi/integration-eduspec-0.json"
-                                         :program-course nil
-                                         :offerings      nil})
-        handle-updated (mock-handle-updated ooapi-loader)
-        actual (handle-updated {::ooapi/id   ooapi-id
-                                ::ooapi/type "education-specification"
-                                :institution-oin institution-oin})]
+  (let [actual (helper/test-handler {::ooapi/id   ooapi-id
+                                     ::ooapi/type "education-specification"
+                                     :institution-oin institution-oin}
+                                    test-resolver
+                                    (mock-ooapi-loader eduspec-req-0))]
     (is (nil? (:errors actual)))
     (is (= "EN TRANSLATION: Computer Science" (-> actual :ooapi :name first :value)))))
 
 (deftest test-handle-updated-eduspec-upcase
-  (let [ooapi-loader (mock-ooapi-loader {:eduspec        "fixtures/ooapi/integration-eduspec-0.json"
-                                         :program-course nil
-                                         :offerings      nil})
+  (let [ooapi-loader (mock-ooapi-loader eduspec-req-0)
         ooapi-loader #(let [x (ooapi-loader %)] (assoc x :educationSpecificationId (str/upper-case (:educationSpecificationId x))))
-        handle-updated (mock-handle-updated ooapi-loader)
-        actual (handle-updated {::ooapi/id   "790c6569-2bcc-d046-dae2-7b73e77231f3"
-                                ::ooapi/type "education-specification"
-                                :institution-oin institution-oin})]
+        actual (helper/test-handler {::ooapi/id   "790c6569-2bcc-d046-dae2-7b73e77231f3"
+                                     ::ooapi/type "education-specification"
+                                     :institution-oin institution-oin}
+                                    test-resolver
+                                    ooapi-loader)]
     (is (nil? (:errors actual)))
     (is (= "790c6569-2bcc-d046-dae2-7b73e77231f3" (get-in actual [:rio-sexp 0 4 2 1])))
     (is (= "EN TRANSLATION: Computer Science" (-> actual :ooapi :name first :value)))))
 
 
 (deftest test-make-eduspec-0
-  (let [ooapi-loader (mock-ooapi-loader {:eduspec        "fixtures/ooapi/integration-eduspec-0.json"
-                                         :program-course nil
-                                         :offerings      nil})
-        r (simulate-upsert ooapi-loader
-                           (slurp (io/resource "fixtures/rio/integration-eduspec-0.xml"))
-                           "education-specification")
-        actual (:result r)]
+  (let [actual (:result (simulate-upsert (mock-ooapi-loader eduspec-req-0)
+                                         (slurp (io/resource "fixtures/rio/integration-eduspec-0.xml"))
+                                         "education-specification"))]
     (is (nil? (:errors actual)))
     (is (= "true" (-> actual :aanleveren_opleidingseenheid_response :requestGoedgekeurd)))))
 
@@ -127,79 +120,61 @@
   (let [ooapi-loader (mock-ooapi-loader {:eduspec        "fixtures/ooapi/integration-eduspec-0.json"
                                          :program-course "fixtures/ooapi/integration-program-0.json"
                                          :offerings      "fixtures/ooapi/integration-program-offerings-0.json"})
-        r (simulate-upsert ooapi-loader
-                           (slurp (io/resource "fixtures/rio/integratie-program-0.xml"))
-                           "program")
-        actual (:result r)
-        mutation (:mutation r)]
-    (is (nil? (:errors actual)))
+        {:keys [result mutation]} (simulate-upsert ooapi-loader
+                                                   (slurp (io/resource "fixtures/rio/integratie-program-0.xml"))
+                                                   "program")]
+    (is (nil? (:errors result)))
     (is (= [:duo:cohortcode "34333"] (get-in mutation [:rio-sexp 0 9 1])))
-    (is (= "true" (-> actual :aanleveren_aangebodenOpleiding_response :requestGoedgekeurd)))))
+    (is (= "true" (-> result :aanleveren_aangebodenOpleiding_response :requestGoedgekeurd)))))
 
-(deftest test-make-fake-joint-program
-  (let [ooapi-loader (mock-ooapi-loader {:program-course "fixtures/ooapi/integration-program-0.json"
-                                         :offerings      "fixtures/ooapi/integration-program-offerings-0.json"})
-        ooapi-loader #(-> (ooapi-loader %)
-                          (update-in [:consumers 1] merge {:jointProgram true}))
-        r (simulate-upsert ooapi-loader
-                           (slurp (io/resource "fixtures/rio/integratie-program-0.xml"))
-                           "program")
-        actual (:result r)
-        mutation (:mutation r)]
-    (is (nil? (:errors actual)))
-    (is (= [:duo:opleidingseenheidSleutel "1234O1234"]
-           (first
-             (filter (fn [v] (and (vector? v) (= (first v) :duo:opleidingseenheidSleutel)))
-                     (-> mutation :rio-sexp first)))))
-    (is (= "true" (-> actual :aanleveren_aangebodenOpleiding_response :requestGoedgekeurd)))))
+(deftest test-joint-program
+  (let [ooapi-loader (mock-ooapi-loader program-req-0)
+        upserter #(simulate-upsert % (slurp (io/resource "fixtures/rio/integratie-program-0.xml")) "program")]
+        ;; after loading program, set jointProgram to true
 
-(deftest test-make-joint-program
-  (let [ooapi-loader (mock-ooapi-loader {:program-course "fixtures/ooapi/integration-program-0.json"
-                                         :offerings      "fixtures/ooapi/integration-program-offerings-0.json"})
-        ooapi-loader #(-> (ooapi-loader %)
-                          (update-in [:consumers 1] merge {:jointProgram      true
-                                                           :educationUnitCode "1234O4323"}))
-        r (simulate-upsert ooapi-loader
-                           (slurp (io/resource "fixtures/rio/integratie-program-0.xml"))
-                           "program")
-        actual (:result r)
-        mutation (:mutation r)]
-    (is (nil? (:errors actual)))
-    (is (= [:duo:opleidingseenheidSleutel "1234O4323"]
-           (first
-             (filter (fn [v] (and (vector? v) (= (first v) :duo:opleidingseenheidSleutel)))
-                     (-> mutation :rio-sexp first)))))
-    (is (= "true" (-> actual :aanleveren_aangebodenOpleiding_response :requestGoedgekeurd)))))
+    (testing "fake joint program"
+      (let [ooapi-loader #(-> (ooapi-loader %)
+                              (update-in [:consumers 1] merge {:jointProgram true}))
+            {:keys [result mutation]} (upserter ooapi-loader)]
+        (is (nil? (:errors result)))
+        (is (= [:duo:opleidingseenheidSleutel "1234O1234"]
+               (first
+                 (filter (fn [v] (and (vector? v) (= (first v) :duo:opleidingseenheidSleutel)))
+                         (-> mutation :rio-sexp first)))))
+        (is (= "true" (-> result :aanleveren_aangebodenOpleiding_response :requestGoedgekeurd)))))
 
-(deftest test-make-joint-program-without-eduspec
-  (let [ooapi-loader (mock-ooapi-loader {:program-course "fixtures/ooapi/integration-program-0.json"
-                                         :offerings      "fixtures/ooapi/integration-program-offerings-0.json"})
-        ooapi-loader #(-> (ooapi-loader %)
-                          (update-in [:consumers 1] merge {:jointProgram      true
-                                                           :educationUnitCode "1234O4323"})
-                          (dissoc :educationSpecification))
-        r (simulate-upsert ooapi-loader
-                           (slurp (io/resource "fixtures/rio/integratie-program-0.xml"))
-                           "program")
-        actual (:result r)
-        mutation (:mutation r)]
-    (is (nil? (:errors actual)))
-    (is (= [:duo:opleidingseenheidSleutel "1234O4323"]
-           (first
-             (filter (fn [v] (and (vector? v) (= (first v) :duo:opleidingseenheidSleutel)))
-                     (-> mutation :rio-sexp first)))))
-    (is (= "true" (-> actual :aanleveren_aangebodenOpleiding_response :requestGoedgekeurd)))))
+    (testing "normal joint program"
+      ;; after loading program, set jointProgram to true
+      (let [ooapi-loader #(-> (ooapi-loader %)
+                              (update-in [:consumers 1] merge {:jointProgram      true
+                                                               :educationUnitCode "1234O4323"}))
+            {:keys [result mutation]} (upserter ooapi-loader)]
+        (is (nil? (:errors result)))
+        (is (= [:duo:opleidingseenheidSleutel "1234O4323"]
+               (first
+                 (filter (fn [v] (and (vector? v) (= (first v) :duo:opleidingseenheidSleutel)))
+                         (-> mutation :rio-sexp first)))))
+        (is (= "true" (-> result :aanleveren_aangebodenOpleiding_response :requestGoedgekeurd)))))
 
-(deftest test-make-joint-program-invalid-code
-  (let [ooapi-loader (mock-ooapi-loader {:program-course "fixtures/ooapi/integration-program-0.json"
-                                         :offerings      "fixtures/ooapi/integration-program-offerings-0.json"})
-        ooapi-loader #(-> (ooapi-loader %)
-                          (update-in [:consumers 1] merge {:jointProgram      true
-                                                           :educationUnitCode "ZAZA"}))]
-    (is (thrown? ExceptionInfo
-                 (simulate-upsert ooapi-loader
-                                  (slurp (io/resource "fixtures/rio/integratie-program-0.xml"))
-                                  "program")))))
+    (testing "joint-program-without-eduspec"
+      (let [ooapi-loader #(-> (ooapi-loader %)
+                              (update-in [:consumers 1] merge {:jointProgram      true
+                                                               :educationUnitCode "1234O4323"})
+                              (dissoc :educationSpecification))
+            {:keys [result mutation]} (upserter ooapi-loader)]
+        (is (nil? (:errors result)))
+        (is (= [:duo:opleidingseenheidSleutel "1234O4323"]
+               (first
+                 (filter (fn [v] (and (vector? v) (= (first v) :duo:opleidingseenheidSleutel)))
+                         (-> mutation :rio-sexp first)))))
+        (is (= "true" (-> result :aanleveren_aangebodenOpleiding_response :requestGoedgekeurd)))))
+
+    (testing "joint-program-invalid-code"
+      (let [ooapi-loader #(-> (ooapi-loader %)
+                              (update-in [:consumers 1] merge {:jointProgram      true
+                                                               :educationUnitCode "ZAZA"}))]
+        (is (thrown? ExceptionInfo
+                     (upserter ooapi-loader)))))))
 
 (deftest test-remove-eduspec-0
   (let [actual (simulate-delete "education-specification"

--- a/test/nl/surf/eduhub_rio_mapper/mapper_integration_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/mapper_integration_test.clj
@@ -129,10 +129,11 @@
 
 (deftest test-joint-program
   (let [ooapi-loader (mock-ooapi-loader program-req-0)
-        upserter #(simulate-upsert % (slurp (io/resource "fixtures/rio/integratie-program-0.xml")) "program")]
-        ;; after loading program, set jointProgram to true
+        upserter #(simulate-upsert % (slurp (io/resource "fixtures/rio/integratie-program-0.xml")) "program")
+        goedgekeurd? (fn [result] (= "true" (-> result :aanleveren_aangebodenOpleiding_response :requestGoedgekeurd)))]
 
     (testing "fake joint program"
+      ;; after loading program, set jointProgram to true
       (let [ooapi-loader #(-> (ooapi-loader %)
                               (update-in [:consumers 1] merge {:jointProgram true}))
             {:keys [result mutation]} (upserter ooapi-loader)]
@@ -141,7 +142,7 @@
                (first
                  (filter (fn [v] (and (vector? v) (= (first v) :duo:opleidingseenheidSleutel)))
                          (-> mutation :rio-sexp first)))))
-        (is (= "true" (-> result :aanleveren_aangebodenOpleiding_response :requestGoedgekeurd)))))
+        (is (goedgekeurd? result))))
 
     (testing "normal joint program"
       ;; after loading program, set jointProgram to true
@@ -154,7 +155,7 @@
                (first
                  (filter (fn [v] (and (vector? v) (= (first v) :duo:opleidingseenheidSleutel)))
                          (-> mutation :rio-sexp first)))))
-        (is (= "true" (-> result :aanleveren_aangebodenOpleiding_response :requestGoedgekeurd)))))
+        (is (goedgekeurd? result))))
 
     (testing "joint-program-without-eduspec"
       (let [ooapi-loader #(-> (ooapi-loader %)
@@ -167,7 +168,7 @@
                (first
                  (filter (fn [v] (and (vector? v) (= (first v) :duo:opleidingseenheidSleutel)))
                          (-> mutation :rio-sexp first)))))
-        (is (= "true" (-> result :aanleveren_aangebodenOpleiding_response :requestGoedgekeurd)))))
+        (is (goedgekeurd? result))))
 
     (testing "joint-program-invalid-code"
       (let [ooapi-loader #(-> (ooapi-loader %)

--- a/test/nl/surf/eduhub_rio_mapper/rio_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/rio_test.clj
@@ -30,6 +30,7 @@
             [nl.surf.eduhub-rio-mapper.rio.opleidingseenheid :as opl-eenh]
             [nl.surf.eduhub-rio-mapper.rio.updated-handler :as updated-handler]
             [nl.surf.eduhub-rio-mapper.specs.ooapi :as ooapi]
+            [nl.surf.eduhub-rio-mapper.test-helper :as helper]
             [nl.surf.eduhub-rio-mapper.utils.keystore :as keystore]
             [nl.surf.eduhub-rio-mapper.utils.soap :as soap]
             [nl.surf.eduhub-rio-mapper.utils.xml-utils :as xml-utils])
@@ -58,10 +59,10 @@
 (def test-handler
   "Loads ooapi fixtures from file and fakes resolver."
   (-> updated-handler/update-mutation
-      (updated-handler/wrap-resolver (fn [ootype _ _] (if (= "education-specification" ootype)
+      (helper/wrap-resolver (fn [ootype _ _] (if (= "education-specification" ootype)
                                                         "1009O1234"
                                                         "12345678-9abc-def0-1234-56789abcdef0")))
-      (ooapi.loader/wrap-load-entities ooapi.loader/ooapi-file-loader)
+      (helper/wrap-load-entities ooapi.loader/ooapi-file-loader)
       (clients-info/wrap-client-info [{:client-id              "rio-mapper-dev.jomco.nl"
                                        :institution-schac-home "demo06.test.surfeduhub.nl"
                                        :institution-oin        "0000000700025BE00000"}])))

--- a/test/nl/surf/eduhub_rio_mapper/test_helper.clj
+++ b/test/nl/surf/eduhub_rio_mapper/test_helper.clj
@@ -23,7 +23,11 @@
     [clojure.java.io :as io]
     [clojure.pprint :refer [pprint]]
     [clojure.string :as str]
-    [clojure.test :refer :all])
+    [clojure.test :refer :all]
+    [nl.surf.eduhub-rio-mapper.ooapi.base :as ooapi-base]
+    [nl.surf.eduhub-rio-mapper.ooapi.loader :as ooapi.loader]
+    [nl.surf.eduhub-rio-mapper.specs.ooapi :as-alias ooapi]
+    [nl.surf.eduhub-rio-mapper.specs.rio :as-alias rio])
   (:import
     [java.io PushbackReader]))
 
@@ -32,6 +36,36 @@
           io/resource
           slurp
           (json/read-str :key-fn keyword)))
+
+(defn wrap-load-entities
+  [f ooapi-loader]
+  (let [loader (ooapi.loader/validating-loader ooapi-loader)]
+    (fn wrapped-load-entities [{:keys [::ooapi/type] :as request}]
+      (f
+        (cond->> request
+                 (not= "relation" type) (ooapi.loader/load-entities loader))))))
+
+(defn wrap-resolver
+  "Get the RIO opleidingscode and aangeboden opleiding code for the given entity.
+
+  Inserts the codes in the request as ::rio/opleidingscode
+  and ::rio/aangeboden-opleiding-code (if entity is a course or
+  program)."
+  [f resolver]
+  (fn with-resolver [{:keys [institution-oin] ::ooapi/keys [type id entity] ::rio/keys [opleidingscode] :as request}]
+    (f (cond-> request
+               (#{"course" "program"} type)
+               (assoc ::rio/aangeboden-opleiding-code
+                      (resolver type id institution-oin))
+
+               true
+               (assoc ::rio/opleidingscode
+                      (or opleidingscode
+                          (resolver "education-specification"
+                                    (if (= type "education-specification")
+                                      id
+                                      (ooapi-base/education-specification-id entity))
+                                    institution-oin)))))))
 
 (defn wait-while-predicate [predicate val-atom max-sec]
   (loop [ttl (* max-sec 10)]

--- a/test/nl/surf/eduhub_rio_mapper/test_helper.clj
+++ b/test/nl/surf/eduhub_rio_mapper/test_helper.clj
@@ -58,7 +58,7 @@
                (assoc ::rio/aangeboden-opleiding-code
                       (resolver type id institution-oin))
 
-               true
+               :always
                (assoc ::rio/opleidingscode
                       (or opleidingscode
                           (resolver "education-specification"


### PR DESCRIPTION
In het hoger onderwijs bestaan er joint degrees: opleidingen die door meer dan één onderwijsintelling verzorgd worden.
In RIO is de eigenaar van de OpleidingsEenheid dan de “penvoerende” instelling. Maar de andere deelnemende instellingen mogen daar dan ook AangebodenOpleidingen voor aanleveren.
DUO vertelde me er het volgende over:
Wanneer een instelling een aangeboden opleiding aanlevert voor een opleidingseenheid die niet van "hem" is, dan bepalen we of de opleidingseenheid (HoOpleiding) een opleidingssamenwerking betreft (Joint Degree).Wanneer dat het geval is bepalen we obv de licenties die gekoppeld zijn aan die HO-opleidingserkenning welke instellingen de opleiding zouden mogen verzorgen. Staat hun instelling in het lijstje voorkomt keuren we de aanlevering goed. Wanneer dat niet zo is ontvangt de instelling een foutcode "N09461 Het onderwijsbestuur maakt geen deel uit van de vastgestelde opleidingssamenwerking".
 
Het doel is dat onze mapper deze functionaliteit gaat ondersteunen. Na wat uitzoekwerk en navragen kom ik tot het volgende ontwerp:
We voegen twee nieuwe velden aan de RIO consumer voor een Program toe:
jointProgram: een boolean. Als die true is, gaan we kijken naar het tweede veld en nemen we een “nieuwe afslag” in de verwerking van het program. Als jointProgram, false is of het hele veld ontbreekt, dan volgen we de oude logica.
educationUnitCode: een string die moet voldoen aan de regex ^\d{4}O\d{4}$ , namelijk een OpleidingsEenheidCode. Als dit veld niet matcht met de regex of ontbreekt terwijl jointProgram true is, moeten we een foutmelding teruggeven.
als jointProgram niet true is word een educationUnitCode niet verwerkt (helemaal genegeerd)
Als een instelling een upsert job aanlevert voor een program en deze beide nieuwe velden zijn correct ingevuld, gaan we het program aanleveren als een AangebodenHoOpleiding, horende bij de OpleidingsEenheid zoals die in educationUnitCode staat.
We slaan het ophalen van de EducationSpecification helemaal over.
Wellicht moet de validatie van Programs aangepast worden: het veld educationSpecification is niet verplicht, als het veld jointProgram true is.
 
Opmerkingen:
We kunnen ervan uitgaan dat een Program wat aangeleverd wordt als jointProgram altijd een AangebodenHoOpleiding is. In RIO bestaan er geen andere vormen die “joint” kunnen zijn.