### PR TITLE
Fix test-rio workflow

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -73,4 +73,5 @@
          :replace-deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
          :main-opts    ["-m" "antq.core"]}
 
-  :mapper {:main-opts ["-m" "nl.surf.eduhub-rio-mapper.main"]}}}
+  :mapper {:extra-paths []
+           :main-opts ["-m" "nl.surf.eduhub-rio-mapper.main"]}}}

--- a/resources/eduspec-test-rio.json
+++ b/resources/eduspec-test-rio.json
@@ -1,0 +1,63 @@
+{
+  "educationSpecificationId": "123e4567-e89b-12d3-a456-426614174000",
+  "primaryCode": {
+    "codeType": "crohoCreboCode",
+    "code": "string"
+  },
+  "otherCodes": [
+    {
+      "codeType": "crohoCreboCode",
+      "code": "1234123"
+    }
+  ],
+  "educationSpecificationType": "program",
+  "name": [
+    {
+      "language": "en-GB",
+      "value": "Bachelor Chemical technology"
+    },
+    {
+      "language": "nl-BE",
+      "value": "Bachelor Chemische technologie"
+    }
+  ],
+  "abbreviation": "B Scheikundige Technologie",
+  "description": [
+    {
+      "language": "en-GB",
+      "value": "program that is a place holder for all courses that are made available for student mobility, program that is a place holder for all courses that are made available for student mobilityprogram that is a place holder for all courses that are made available for student mobilityprogram that is a place holder for all courses that are made available for student mobilityprogram that is a place holder for all courses that are made available for student mobilityprogram that is a place holder for all courses that are made available for student mobilityprogram that is a place holder for all courses that are made available for student mobilityprogram that is a place holder for all courses that are made available for student mobilityprogram that is a place holder for all courses that are made available for student mobilityprogram that is a place holder for all courses that are made available for student mobilityprogram that is a place holder for all courses that are made available for student mobilityprogram that is a place holder for all courses that are made available for student mobility"
+    }
+  ],
+  "formalDocument": "diploma",
+  "level": "master",
+  "sector": "university education",
+  "levelOfQualification": "6",
+  "fieldsOfStudy": "0732",
+  "studyLoad": {
+    "studyLoadUnit": "ects",
+    "value": 3
+  },
+  "learningOutcomes": [
+    [
+      {
+        "language": "en-GB",
+        "value": "Executable knowledge of Chemical technology, including: Acquire knowledge of research paradigms."
+      }
+    ]
+  ],
+  "link": "https://bijvak.nl",
+  "parent": "42e2bc1b-6741-4e2e-b138-97b4a342c999",
+  "children": [
+    "497f6eca-6276-4993-bfeb-53cbbbba6f08"
+  ],
+  "organization": "452c1a86-a0af-475b-b03f-724878b0f387",
+  "consumers": [
+    {
+      "consumerKey": "rio",
+      "educationSpecificationSubType": "variant"
+    }
+  ],
+  "ext": {},
+  "validFrom": "2019-08-24",
+  "validTo": "2019-08-25"
+}

--- a/src/nl/surf/eduhub_rio_mapper/cli_commands.clj
+++ b/src/nl/surf/eduhub_rio_mapper/cli_commands.clj
@@ -81,7 +81,7 @@
           old-uuid     (UUID/randomUUID)
           new-uuid     (UUID/randomUUID)
 
-          eduspec (-> "../test/fixtures/ooapi/education-specification-template.json"
+          eduspec (-> "eduspec-test-rio.json"
                       io/resource
                       slurp
                       (json/read-str :key-fn keyword)


### PR DESCRIPTION
The test-rio workflow used a file in the test dir, and after the lein-deps migration the test dir was no longer on the classpath.

