### PR TITLE
Various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test-redis:
 	clojure -M:test $(TEST_OPTS) --focus-meta :redis
 
 test-e2e:
-	clojure -M:test $(TEST_OPTS) --focus-meta :e2e
+	clojure -M:test $(TEST_OPTS) --focus-meta :e2e --no-capture-output
 
 test-all:
 	clojure -M:test

--- a/src/nl/surf/eduhub_rio_mapper/endpoints/app_server.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/app_server.clj
@@ -21,6 +21,7 @@
   (:import [org.eclipse.jetty.server HttpConnectionFactory]))
 
 (defn run-jetty [app host port]
+  (println (str "Starting Jetty on port " port))
   (jetty/run-jetty app
                    {:host         host
                     :port         port

--- a/test/nl/surf/eduhub_rio_mapper/e2e_helper.clj
+++ b/test/nl/surf/eduhub_rio_mapper/e2e_helper.clj
@@ -577,7 +577,7 @@
                         {:msecs wait-for-serve-api-total-msec})))
       (let [result
             (try
-              (http/get (str @base-url "/metrics")
+              (http/get (str @base-url "/health")
                         {:throw-exceptions false})
               true
               (catch ConnectException _

--- a/test/nl/surf/eduhub_rio_mapper/e2e_helper.clj
+++ b/test/nl/surf/eduhub_rio_mapper/e2e_helper.clj
@@ -538,9 +538,15 @@
       (println "The api and the worker must run on separate ports.")
       (System/exit 1)))
   (doseq [{:keys [cmd proc-atom log-file]} services]
-    (let [process-builder (ProcessBuilder. (into ["clojure" "-M:mapper"] cmd))]
+
+    (let [process-builder (ProcessBuilder. (into ["clojure" "-M:mapper"] cmd))
+          log-file (File. log-file)]
+      (when-let [parent (.getParentFile log-file)]
+        (.mkdirs parent))
+      (when-not (.exists log-file)
+        (.createNewFile log-file))
       (.redirectErrorStream process-builder true)
-      (.redirectOutput process-builder (File. log-file))
+      (.redirectOutput process-builder log-file)
       (println "Starting mapper" cmd)
       (reset! proc-atom (.start process-builder)))))
 

--- a/test/nl/surf/eduhub_rio_mapper/e2e_helper.clj
+++ b/test/nl/surf/eduhub_rio_mapper/e2e_helper.clj
@@ -33,7 +33,7 @@
             [nl.surf.eduhub-rio-mapper.utils.xml-utils :as xml-utils])
   (:import [java.io File StringWriter]
            [java.net ConnectException]
-           [java.util Base64]
+           [java.util Base64 List]
            [javax.xml.xpath XPathConstants XPathFactory]
            [org.w3c.dom Node NodeList]))
 
@@ -259,7 +259,7 @@
 
                      :else
                      (do
-                       (Thread/sleep job-status-poll-sleep-msecs)
+                       (Thread/sleep ^long job-status-poll-sleep-msecs)
                        (recur (dec tries-left)))))))))))
 
 (defn job-result
@@ -537,9 +537,9 @@
     (when (= (:api-config config) (:worker-api-config config))
       (println "The api and the worker must run on separate ports.")
       (System/exit 1)))
-  (doseq [{:keys [cmd proc-atom log-file]} services]
+  (doseq [{:keys [cmd proc-atom ^String log-file]} services]
 
-    (let [process-builder (ProcessBuilder. (into ["clojure" "-M:mapper"] cmd))
+    (let [process-builder (ProcessBuilder. ^List (into ["clojure" "-M:mapper"] cmd))
           log-file (File. log-file)]
       (when-let [parent (.getParentFile log-file)]
         (.mkdirs parent))
@@ -583,7 +583,7 @@
               (catch ConnectException _
                 false))]
         (when-not result
-          (Thread/sleep wait-for-serve-api-sleep-msec)
+          (Thread/sleep ^long wait-for-serve-api-sleep-msec)
           (recur (dec tries-left))))))
 
   ;; run tests


### PR DESCRIPTION
- **Create log file if it doesn't exist**
- **Check correct endpoint to see if server has started (e2e-tests)
- **Don't capture output; annotate types**
