### PR TITLE
Use nonroot distroless variant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY . /app/
 RUN make jar
 
-FROM gcr.io/distroless/java21-debian12
+FROM gcr.io/distroless/java21-debian12:nonroot
 COPY --from=builder /app/target/eduhub-rio-mapper.jar /eduhub-rio-mapper.jar
 # Make sure there is an opentelemetry agent in the workdir in case docker-compose
 # starts up a process with -javaagent in the JAVA_TOOL_OPTIONS

--- a/README.md
+++ b/README.md
@@ -183,11 +183,16 @@ The `CLIENTS_INFO_PATH` should specify a json file with settings for client-id, 
 
 ## Docker containers
 
-The application consists of two parts: the *API* and the *Worker*. Both
-components can be started from a single docker image
-for which a [./Dockerfile](Dockerfile) is included. See for the
-configuration options the [./CLI.md](CLI) documentation and note that
-these containers both need access to the same *redis*
+The application consists of two parts: the *API* and the
+*Worker*. Both components can be started from a single docker image
+for which a [./Dockerfile](Dockerfile) is included.  The image build
+is *nonroot* variant of *distroless* Debian which runs the CLI as:
+
+- *user*: `nonroot` (uid=65532)
+- *group*: `nonroot` (guid=65532)
+
+See for the configuration options the [./CLI.md](CLI) documentation
+and note that these containers both need access to the same *redis*
 server.
 
 Build the docker image with:


### PR DESCRIPTION
The services will run as:

  user: nonroot (uid=65532)
  group: nonroot (guid=65532)

I can't find proper documentation but see also:

- https://github.com/GoogleContainerTools/distroless/blob/2ce552d3bd5db0edb82602edbeabcbb5159329d1/common/BUILD.bazel#L123
- https://github.com/GoogleContainerTools/distroless/blob/2ce552d3bd5db0edb82602edbeabcbb5159329d1/common/variables.bzl#L18