### PR TITLE
Fixed test keystore

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -33,7 +33,7 @@
          ch.qos.logback/logback-classic              {:mvn/version "1.5.18"}
          com.fasterxml.jackson.core/jackson-core     {:mvn/version "2.19.0"}
          com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.19.0"}
-         com.github.steffan-westcott/clj-otel-api    {:mvn/version "0.2.7"}}
+         com.github.steffan-westcott/clj-otel-api    {:mvn/version "0.2.8"}}
 
  :aliases
  {:dev {:extra-paths ["dev"]

--- a/test/nl/surf/eduhub_rio_mapper/test_helper.clj
+++ b/test/nl/surf/eduhub_rio_mapper/test_helper.clj
@@ -137,6 +137,7 @@
 ;; The truststore used for unit tests has a different password than the official password.
 ;; The truststore (as opposed to the keystore) does not contain sensitive or private data.
 (defn make-test-config []
-  (config/make-config (assoc env :keystore-password "xxxxxx"
+  (config/make-config (assoc env :keystore "test/keystore.jks"
+                                 :keystore-password "xxxxxx"
                                  :truststore-password "xxxxxx"
                                  :keystore-alias "test-surf")))


### PR DESCRIPTION
Tests should use keystore in test/keystore.jks regardless of the ENV vars.
