### PR TITLE
Handle and log invalid json

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
           username: ${{ secrets.ARTIFACTORY_USERNAME }}
           password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       - name: Build and push
-        uses: docker/build-push-action@v6.17
+        uses: docker/build-push-action@v6.18
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
https://trello.com/c/1rmkzt3a

I cannot parse the nippy data in the redis string. 
So I'm going to catch the exception, log it, and just not add the json-body field, which is for debugging anyway.

