### PR TITLE
Ensure no credentials in logs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps  {org.clojure/clojure      {:mvn/version "1.12.2"}
+ :deps  {org.clojure/clojure      {:mvn/version "1.12.3"}
          org.clojure/core.async   {:mvn/version "1.8.741"}
          org.clojure/core.memoize {:mvn/version "1.1.266"}
 
@@ -13,10 +13,10 @@
          com.velisco/strgen          {:mvn/version "0.2.5" :exclusions [org.clojure/clojurescript]}
 
          ;; http
-         ring/ring-core                 {:mvn/version "1.14.2"}
-         ring/ring-jetty-adapter        {:mvn/version "1.14.2"}
-         ring/ring-defaults             {:mvn/version "0.6.0"}
-         compojure/compojure            {:mvn/version "1.7.1"}
+         ring/ring-core                 {:mvn/version "1.15.3"}
+         ring/ring-jetty-adapter        {:mvn/version "1.15.3"}
+         ring/ring-defaults             {:mvn/version "0.7.0"}
+         compojure/compojure            {:mvn/version "1.7.2"}
          nl.jomco/ring-trace-context    {:mvn/version "0.0.8"}
          nl.jomco/clj-http-status-codes {:mvn/version "0.2"}
 
@@ -33,7 +33,7 @@
          ch.qos.logback/logback-classic              {:mvn/version "1.5.18"}
          com.fasterxml.jackson.core/jackson-core     {:mvn/version "2.20.0"}
          com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.20.0"}
-         com.github.steffan-westcott/clj-otel-api    {:mvn/version "0.2.8"}}
+         com.github.steffan-westcott/clj-otel-api    {:mvn/version "0.2.9"}}
 
  :aliases
  {:dev {:extra-paths ["dev"]

--- a/dev/generate_enums/main.clj
+++ b/dev/generate_enums/main.clj
@@ -1,6 +1,6 @@
 (ns generate-enums.main
   (:require [clj-yaml.core :as yaml]
-            [clojure.string :as string]
+            [clojure.string :as str]
             [clojure.java.io :as io]))
 
 (defn generate-enum
@@ -16,7 +16,7 @@
          "\n  \""
          docstring
          "\"\n  #{"
-         (string/join " " (map #(str "\"" % "\"") values))
+         (str/join " " (map #(str "\"" % "\"") values))
          "})\n\n")))
 
 (defn -main

--- a/src/nl/surf/eduhub_rio_mapper/endpoints/metrics.clj
+++ b/src/nl/surf/eduhub_rio_mapper/endpoints/metrics.clj
@@ -17,8 +17,7 @@
 ;; <https://www.gnu.org/licenses/>.
 
 (ns nl.surf.eduhub-rio-mapper.endpoints.metrics
-  (:require [clojure.string]
-            [steffan-westcott.clj-otel.api.metrics.instrument :as instrument]))
+  (:require [steffan-westcott.clj-otel.api.metrics.instrument :as instrument]))
 
 (defn count-queues [grouped-queue-counter client-schac-homes]
   {:post [(map? %)

--- a/src/nl/surf/eduhub_rio_mapper/utils/ooapi.clj
+++ b/src/nl/surf/eduhub_rio_mapper/utils/ooapi.clj
@@ -1,5 +1,5 @@
 (ns nl.surf.eduhub-rio-mapper.utils.ooapi
-  (:require [clojure.string :as string]
+  (:require [clojure.string :as str]
             [nl.surf.eduhub-rio-mapper.rio.helper :as rio-helper])
   (:import [java.time LocalDate]
            [java.time.format DateTimeFormatter DateTimeParseException]
@@ -25,7 +25,7 @@
   [attr & [locales]]
   (->> locales
        (keep (fn [locale]
-               (some #(when (string/starts-with? (% :language) locale)
+               (some #(when (str/starts-with? (% :language) locale)
                         (% :value))
                      attr)))
        first))

--- a/src/nl/surf/eduhub_rio_mapper/utils/soap.clj
+++ b/src/nl/surf/eduhub_rio_mapper/utils/soap.clj
@@ -19,7 +19,7 @@
 (ns nl.surf.eduhub-rio-mapper.utils.soap
   (:require
    [clojure.data.xml :as clj-xml]
-   [clojure.string :as string]
+   [clojure.string :as str]
    [nl.surf.eduhub-rio-mapper.utils.xml-utils :as xml-utils])
   (:import
    (java.io ByteArrayOutputStream)
@@ -56,7 +56,7 @@
 (defn- text-content= [^Element element ^String content] (.setTextContent element content))
 
 (defn- to-ns [prefix schema] (str "xmlns:" prefix "=\"" schema "\""))
-(defn xmlns [prefix-schema] (string/join " " (map #(to-ns (first %) (last %)) prefix-schema)))
+(defn xmlns [prefix-schema] (str/join " " (map #(to-ns (first %) (last %)) prefix-schema)))
 
 (def parts-data {"From" ["duo soapenv" ["soapenv:Header" "wsa:From"]]
                  "To"        ["duo soapenv" ["soapenv:Header" "wsa:To"]]
@@ -149,7 +149,7 @@
   (sign-sha256rsa (canonicalize-excl signed-info "wsa duo soapenv") private-key))
 
 (defn request-body [action rio-sexp schema sender-oin recipient-oin]
-  {:pre [sender-oin recipient-oin (not (string/blank? action))]}
+  {:pre [sender-oin recipient-oin (not (str/blank? action))]}
   (into [(keyword (str "duo:" action "_request")) {:xmlns:duo schema}
          [:duo:identificatiecodeBedrijfsdocument (UUID/randomUUID)]
          [:duo:verzendendeInstantie sender-oin]

--- a/test/nl/surf/eduhub_rio_mapper/interaction_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/interaction_test.clj
@@ -127,7 +127,7 @@
                     "verwijderen_opleidingsrelatie"
                     "aanleveren_opleidingsrelatie"]
                    (mapv #(when-let [soap-action (get-in http-messages [% :req :headers "SOAPAction"])]
-                            (last (clojure.string/split soap-action #"/")))
+                            (last (str/split soap-action #"/")))
                          (range 0 (count http-messages)))))))))
 
     (testing "Delete program using code not id"

--- a/test/nl/surf/eduhub_rio_mapper/remote_entities_helper.clj
+++ b/test/nl/surf/eduhub_rio_mapper/remote_entities_helper.clj
@@ -67,7 +67,7 @@
   exposed by the gateway and accessable to the test client."
   (:require [clj-http.client :as client]
             [clojure.java.io :as io]
-            [clojure.string :as string]
+            [clojure.string :as str]
             [environ.core :refer [env]]
             [nl.jomco.envopts :as envopts])
   (:import java.util.UUID))
@@ -125,7 +125,7 @@
   "Create a request to the ObjectStore."
   [{:keys [token storage-url] :as _info} method path]
   {:headers {"X-Auth-Token" token}
-   :url     (str (string/replace storage-url #"/$" "") path)
+   :url     (str (str/replace storage-url #"/$" "") path)
    :accept  :json
    :as      :json
    :method  method})
@@ -198,7 +198,7 @@
 
 (defn- file->base
   [file]
-  (string/replace
+  (str/replace
    (subs (.getCanonicalPath file)
          (inc (count (.getCanonicalPath (entities-dir)))))
    #"\.json$" ""))
@@ -233,7 +233,7 @@
 
 (defn- replace-content-exprs
   [templ session]
-  (string/replace templ
+  (str/replace templ
                   #"\{\{\s*([^}\s]+)\s*}\}"
                   (fn [[_ name]]
                     (str (or (get session name)
@@ -252,9 +252,9 @@
   (let [loc (file->base f)]
     (loop [[[k v] & more] session]
       (assert k)
-      (if (string/starts-with? loc k)
+      (if (str/starts-with? loc k)
         (let [[_ base] (re-matches #"^([^/]+)/.*" k)]
-          (str base "/" (string/replace loc k (str v))))
+          (str base "/" (str/replace loc k (str v))))
         (recur more)))))
 
 (defn remote-objects

--- a/test/nl/surf/eduhub_rio_mapper/utils/logging_test.clj
+++ b/test/nl/surf/eduhub_rio_mapper/utils/logging_test.clj
@@ -1,0 +1,83 @@
+;; This file is part of eduhub-rio-mapper
+;;
+;; Copyright (C) 2022 SURFnet B.V.
+;;
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU Affero General Public License
+;; as published by the Free Software Foundation, either version 3 of
+;; the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; Affero General Public License for more details.
+;;
+;; You should have received a copy of the GNU Affero General Public
+;; License along with this program.  If not, see
+;; <https://www.gnu.org/licenses/>.
+
+(ns nl.surf.eduhub-rio-mapper.utils.logging-test
+  (:require
+    [clojure.string :as str]
+    [clojure.test :refer :all]
+    [nl.surf.eduhub-rio-mapper.utils.logging :refer [->mdc-entry redact-placeholder]]))
+
+(deftest mdc-entry-test
+
+  (testing "simple string key and value"
+    (is (= ["foo" "bar"]
+           (->mdc-entry ["foo" "bar"]))))
+
+  (testing "keyword key with string value"
+    (is (= ["test-key" "test-value"]
+           (->mdc-entry [:test-key "test-value"]))))
+
+  (testing "qualified keyword key"
+    (is (= ["my.ns/test-key" "test-value"]
+           (->mdc-entry [:my.ns/test-key "test-value"]))))
+
+  (testing "keyword value gets converted to string without colon"
+    (is (= ["key" "keyword-value"]
+           (->mdc-entry ["key" :keyword-value]))))
+
+  (testing "sequential value gets formatted as comma-separated quoted values"
+    (is (= ["items" "'one', 'two', 'three'"]
+           (->mdc-entry ["items" ["one" "two" "three"]]))))
+
+  (testing "map value gets formatted as key => value pairs"
+    (is (= ["config" "{ name => test-app, version => 1.0 }"]
+           (->mdc-entry ["config" {"name" "test-app" "version" "1.0"}]))))
+
+  (testing "numeric value gets converted to string"
+    (is (= ["count" "42"]
+           (->mdc-entry ["count" 42]))))
+
+  (testing "password key gets redacted"
+    (is (= ["password" redact-placeholder]
+           (->mdc-entry ["password" "secret123"]))))
+
+  (testing "secret key gets redacted (case sensitive)"
+    (is (= ["secret_token" redact-placeholder]
+           (->mdc-entry ["secret_token" "very-secret-value"]))))
+
+  (testing "secret key gets redacted (case insensitive)"
+    (is (= ["SECRET_TOKEN" redact-placeholder]
+           (->mdc-entry ["SECRET_TOKEN" "very-secret-value"]))))
+
+  (testing "client-id key gets redacted"
+    (is (= ["client-id" redact-placeholder]
+           (->mdc-entry ["client-id" "client-12345"]))))
+
+  (testing "deeply nested sensitive data gets redacted"
+    (let [[k formatted] (->mdc-entry
+                          [:session
+                           {:level1 {:auth {:secret_token "secret-value"
+                                            :proxy-options {:password "pw"}}
+                                     :clients [{:client-id "client-6789"
+                                                :notes ["safe-value" {:passcode "abc123"}]}]}}])]
+      (is (= "session" k))
+      (is (str/includes? formatted redact-placeholder))
+      (is (not (str/includes? formatted "secret-value")))
+      (is (not (str/includes? formatted "client-6789")))
+      (is (not (str/includes? formatted "abc123")))
+      (is (str/includes? formatted "safe-value")))))


### PR DESCRIPTION
Sensitive data was only being redacted on the top level, not recursively.
Additionally, detection of protected keywords was case sensitive.

Ticket: https://trello.com/b/QIYeA275/surf-eduhub-rio-mapper

I've also added tests in logging-test.

To reproduce, in logging/wrap-errors, change:

```
      (when (and throw-exceptions
                 (not (http-status/success-status? (:status response))))
```

to 

```
      (when (and throw-exceptions
                 (not (http-status/success-status? 500)))
```

Then run `make test-e2e` and look in the worker log.

New format:

```json
{"timestamp":"2025-09-26T11:43:46.336Z",
 "level":"ERROR",
 "thread":"runner-endpoint01.sandbox.jomco.nl",
 "mdc":{"phase":"unknown",
 "request":"{ keystore-alias => cert-2025, keystore => java.security.KeyStore@23522586, keystore-pass => XXX-REDACTED, method => post, trust-store => java.security.KeyStore@2f357114, trust-store-pass => XXX-REDACTED, headers => { SOAPAction => http://duo.nl/contract/DUO_RIO_Raadplegen_OnderwijsOrganisatie_V4/opvragen_opleidingseenheid, traceparent => 00-86a7a9471a9322af73515827f5ea2bf5-3b50d9a00ff119e4-00 }, certificate => [B@24c44ef1, trace-context => { version => 00, trace-id => 86a7a9471a9322af73515827f5ea2bf5, parent-id => 3b50d9a00ff119e4, trace-flags => #{} }, url => https://vt-webservice.duo.nl:6977/RIO/services/raadplegen4.0, content-type => xml, body => <?xml version=\"1.0\" encod...
```
 
