### PR TITLE
Fix Bug HOOpleiding variant einddatum

### DIFF
--- a/src-v5/nl/surf/eduhub_rio_mapper/v5/commands/processing.clj
+++ b/src-v5/nl/surf/eduhub_rio_mapper/v5/commands/processing.clj
@@ -100,11 +100,12 @@
   [eduspec {:keys [valid-from valid-to] :as _relation}]
   (let [eduspec-valid-from (:validFrom eduspec)
         eduspec-valid-to   (:validTo eduspec)
-        valid-from-check (or (nil? eduspec-valid-from)
-                            (<= 0 (compare valid-from eduspec-valid-from)))
-        valid-to-check   (or (nil? valid-to)
-                            (nil? eduspec-valid-to)
-                            (>= 0 (compare valid-to eduspec-valid-to)))
+        valid-from-check (if (and valid-from eduspec-valid-from)
+                           (<= 0 (compare valid-from eduspec-valid-from))
+                           (nil? eduspec-valid-from))
+        valid-to-check   (if (and valid-to eduspec-valid-to)
+                           (>= 0 (compare valid-to eduspec-valid-to))
+                           (nil? eduspec-valid-to))
         is-valid (and valid-from-check valid-to-check)]
     is-valid))
 

--- a/test-common/fixtures/remote-entities/education-specifications/bonuschild-program.json
+++ b/test-common/fixtures/remote-entities/education-specifications/bonuschild-program.json
@@ -1,0 +1,70 @@
+{
+  "level": "bachelor",
+  "parent": "{{education-specifications/bonusparent-program}}",
+  "organization": "cafecafe-cafe-cafe-cafe-cafecafecafe",
+  "educationSpecificationType": "program",
+  "educationSpecificationId": "{{education-specifications/bonuschild-program}}",
+  "validFrom": "2016-12-15",
+  "abbreviation": "OT",
+  "learningOutcomes": [
+    [
+      {
+        "language": "en-GB",
+        "value": "child program eduspec"
+      },
+      {
+        "language": "nl-NL",
+        "value": "child program eduspec"
+      }
+    ]
+  ],
+  "formalDocument": "diploma",
+  "sector": "higher professional education",
+  "name": [
+    {
+      "language": "en-GB",
+      "value": "bonuschild-program education specification"
+    },
+    {
+      "language": "nl-NL",
+      "value": "bonuschild-program education specification"
+    }
+  ],
+  "primaryCode": {
+    "codeType": "identifier",
+    "code": "{{education-specifications/bonuschild-program}}"
+  },
+  "link": "https://universiteit-van-boxtel.nl/education-specifications/{{education-specifications/bonuschild-program}}",
+  "fieldsOfStudy": "0612",
+  "description": [
+    {
+      "language": "en-GB",
+      "value": ".."
+    },
+    {
+      "language": "nl-NL",
+      "value": ".."
+    }
+  ],
+  "levelOfQualification": "6",
+  "consumers": [
+    {
+      "consumerKey": "rio",
+      "educationSpecificationSubType": "variant",
+      "category": [
+        "business_and_project_support",
+        "hobby_and_leisure_time",
+        "technology_and_ict",
+        "transport_and_logistics",
+        "law",
+        "agriculture_food_and_natural_environment",
+        "healthcare_and_sport",
+        "tourism_hospitality_and_recreation"
+      ]
+    }
+  ],
+  "studyLoad": {
+    "value": 128,
+    "studyLoadUnit": "ects"
+  }
+}

--- a/test-common/fixtures/remote-entities/education-specifications/bonusparent-program.json
+++ b/test-common/fixtures/remote-entities/education-specifications/bonusparent-program.json
@@ -1,0 +1,76 @@
+{
+  "level": "bachelor",
+  "children": ["{{education-specifications/bonuschild-program}}"],
+  "organization": "cafecafe-cafe-cafe-cafe-cafecafecafe",
+  "educationSpecificationType": "program",
+  "educationSpecificationId": "{{education-specifications/bonusparent-program}}",
+  "validFrom": "1950-09-20",
+  "abbreviation": "1T",
+  "learningOutcomes": [
+    [
+      {
+        "language": "en-GB",
+        "value": ".."
+      },
+      {
+        "language": "nl-NL",
+        "value": ".."
+      }
+    ],
+    [
+      {
+        "language": "en-GB",
+        "value": ".."
+      },
+      {
+        "language": "nl-NL",
+        "value": ".."
+      }
+    ]
+  ],
+  "formalDocument": "diploma",
+  "sector": "higher professional education",
+  "name": [
+    {
+      "language": "en-GB",
+      "value": "bonusparent-program education specification"
+    },
+    {
+      "language": "nl-NL",
+      "value": "bonusparent-program education specification"
+    }
+  ],
+  "primaryCode": {
+    "codeType": "identifier",
+    "code": "{{education-specifications/bonusparent-program}}"
+  },
+  "link": "https://universiteit-van-boxtel.nl/education-specifications/{{education-specifications/bonusparent-program}}",
+  "fieldsOfStudy": "0912",
+  "description": [
+    {
+      "language": "en-GB",
+      "value": ".."
+    },
+    {
+      "language": "nl-NL",
+      "value": ".."
+    }
+  ],
+  "levelOfQualification": "6",
+  "consumers": [
+    {
+      "consumerKey": "rio",
+      "category": [
+        "business_and_project_support",
+        "education",
+        "cross_sectoral",
+        "language_and_culture",
+        "technology_and_ict"
+      ]
+    }
+  ],
+  "studyLoad": {
+    "value": 93,
+    "studyLoadUnit": "sbu"
+  }
+}


### PR DESCRIPTION
Trello ticket: https://trello.com/c/7DrDfhVI/327-bug-hoopleiding-variant-einddatum-aanpassen

Een klant loopt tegen een bug aan waarbij RIO het niet accepteert als de einddatum van een HoOpleidingsVariant wordt aangepast. Het is dezelfde klant en ook eigenlijk dezelfde bug als in dit eerdere ticket, maar daar ging het om de begindatum. Bug HOopleiding variant datumwijziging
DEPLOYED IN PROD / DONE
Wij vermoeden dat het probleem is dat de einddatum van de opleidingsrelatie niet wordt aangepast/opgevoerd, en dat deze dus eerst aangepast moet worden voordat RIO de wijziging van de einddatum van de opleidingsvariant accepteert. In dit geval heeft de relatie geen einddatum en gaat het vermoedelijk daarom fout.