### PR TITLE
Add push to harbor registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: eduhub-docker-production.artie.ia.surfsara.nl/rio-mapper
+          images: |
+            eduhub-docker-production.artie.ia.surfsara.nl/rio-mapper
+            cr.surf.nl/surfeduhub-riomapper/riomapper
           tags: |
             type=match,pattern=v\d+.\d+
             type=sha,format=long
@@ -29,6 +31,12 @@ jobs:
           registry: eduhub-docker-production.artie.ia.surfsara.nl
           username: ${{ secrets.ARTIFACTORY_USERNAME }}
           password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          registry: cr.surf.nl
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
       - name: Build and push
         uses: docker/build-push-action@v7
         with:


### PR DESCRIPTION
We gaan gebruik maken van een andere image repository, deze change zorgt ervoor dat de gebouwde images naar beide repositories gepusht worden.