### PR TITLE
Unwrap ooapi loader

### DIFF
--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/cli_commands.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/cli_commands.clj
@@ -64,7 +64,7 @@
       (System/exit 1))
     [client-info rest-args]))
 
-(defn process-command [command args {{:keys [getter resolver ooapi-loader-config dry-run! link! insert!] :as handlers} :handlers {:keys [clients] :as config} :config}]
+(defn process-command [command args {{:keys [getter resolver dry-run! link! insert!] :as handlers} :handlers {:keys [clients] :as config} :config}]
   {:pre [getter]}
   (case command
     "serve-api"
@@ -136,7 +136,7 @@
     (let [[client-info [type id]] (parse-client-info-args args clients)
           request (merge client-info {::ooapi/id id ::ooapi/type type})]
       (if (= "show" command)
-        (-> (ooapi.loader/ooapi-http-load request ooapi-loader-config)
+        (-> (ooapi.loader/ooapi-http-loader (merge request (ooapi.loader/request-gateway-opts config)))
             (json/pprint))
         (dry-run! request)))
 

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/cli_commands.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/cli_commands.clj
@@ -136,7 +136,7 @@
     (let [[client-info [type id]] (parse-client-info-args args clients)
           request (merge client-info {::ooapi/id id ::ooapi/type type})]
       (if (= "show" command)
-        (-> (ooapi.loader/ooapi-http-loader (merge request (ooapi.loader/request-gateway-opts config)))
+        (-> (ooapi.loader/ooapi-http-loader (assoc request :config config))
             (json/pprint))
         (dry-run! request)))
 

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/cli_commands.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/cli_commands.clj
@@ -32,6 +32,7 @@
             [nl.surf.eduhub-rio-mapper.v6.config :as config]
             [nl.surf.eduhub-rio-mapper.v6.endpoints.api :as api]
             [nl.surf.eduhub-rio-mapper.v6.job :as job]
+            [nl.surf.eduhub-rio-mapper.v6.ooapi.loader :as ooapi.loader]
             [nl.surf.eduhub-rio-mapper.worker :as worker])
   (:import [java.util UUID]))
 
@@ -63,7 +64,7 @@
       (System/exit 1))
     [client-info rest-args]))
 
-(defn process-command [command args {{:keys [getter resolver ooapi-loader dry-run! link! insert!] :as handlers} :handlers {:keys [clients] :as config} :config}]
+(defn process-command [command args {{:keys [getter resolver ooapi-loader-config dry-run! link! insert!] :as handlers} :handlers {:keys [clients] :as config} :config}]
   {:pre [getter]}
   (case command
     "serve-api"
@@ -135,7 +136,7 @@
     (let [[client-info [type id]] (parse-client-info-args args clients)
           request (merge client-info {::ooapi/id id ::ooapi/type type})]
       (if (= "show" command)
-        (-> (ooapi-loader request)
+        (-> (ooapi.loader/ooapi-http-load request ooapi-loader-config)
             (json/pprint))
         (dry-run! request)))
 

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/commands/processing.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/commands/processing.clj
@@ -312,7 +312,7 @@
     (fn [request]
       {:pre [(:institution-oin request)]}
       (as-> request $
-        (merge $ (ooapi.loader/request-gateway-opts config))
+        (assoc $ :config config)
         (reduce (fn [req f] (f req)) $ wrapped-fs)
         (merge (:mutate-result $) (select-keys (:job $) [::rio/aangeboden-opleiding-code]))))))
 
@@ -329,7 +329,7 @@
     (fn [request]
       {:pre [(:institution-oin request)]}
       (as-> request $
-        (merge $ (ooapi.loader/request-gateway-opts config))
+        (assoc $ :config config)
         (reduce (fn [req f] (f req)) $ wrapped-fs)
         (:mutate-result $)))))
 
@@ -371,7 +371,7 @@
 (defn- make-dry-runner [handlers config]
   (fn [{::ooapi/keys [type] :as request}]
     {:pre [(:institution-oin request)]}
-    (let [request (merge request (ooapi.loader/request-gateway-opts config))
+    (let [request (assoc request :config config)
           entity  (try-load-entity request)
           value   (if-not entity
                     {:status "error"}

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/commands/processing.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/commands/processing.clj
@@ -68,35 +68,32 @@
 
 ;; Only function of this phase is to load programmes in order to distinguish
 ;; programmes from programme-specifications, which are different object in RIO
-(defn- make-deleter-load-ooapi-phase [{:keys [ooapi-loader-config]}]
-  (fn load-ooapi-phase [{::ooapi/keys [type id] :as request}]
-    {:pre  [(#{"programme" "course"} type)]
-     :post [(:rio-type %)]}
-    (if (= type "course")
-      (assoc request :rio-type :ao)
-      (logging/with-mdc
-        {:ooapi-type type :ooapi-id id}
-        (let [entity (ooapi.loader/ooapi-http-load request ooapi-loader-config)]
-          (assoc request :rio-type (if (and (= "programme" type)
-                                            (= "specification" (:programmeType entity)))
-                                     :oe
-                                     :ao)))))))
+(defn- load-ooapi-phase-for-delete [{::ooapi/keys [type id] :as request}]
+  {:pre  [(#{"programme" "course"} type)]
+   :post [(:rio-type %)]}
+  (if (= type "course")
+    (assoc request :rio-type :ao)
+    (logging/with-mdc
+      {:ooapi-type type :ooapi-id id}
+      (let [entity (ooapi.loader/ooapi-http-loader request)]
+        (assoc request :rio-type (if (and (= "programme" type)
+                                          (= "specification" (:programmeType entity)))
+                                   :oe
+                                   :ao))))))
 
 ;; in:  {::ooapi/keys [type id] :keys [action institution-name institution-oin institution-schac-home]}
 ;; diff out: {:keys [rio-type] ::ooapi/keys [entity]}
-:nl.surf.eduhub-rio-mapper.v6.specs.ooapi/specification-type
-(defn- make-updater-load-ooapi-phase [{:keys [ooapi-loader-config]}]
-  (fn load-ooapi-phase [{::ooapi/keys [type id] :as request}]
-    {:pre  [(#{"programme" "course"} type)]
-     :post [(:rio-type %)]}
-    (logging/with-mdc
-      {:ooapi-type type :ooapi-id id}
-      (let [{::ooapi/keys [entity] :as result} (ooapi.loader/load-entities ooapi-loader-config request)]
-        (quick-validate entity type)
-        (assoc result :rio-type (if (and (= "programme" type)
-                                         (= "specification" (:programmeType entity)))
-                                  :oe
-                                  :ao))))))
+(defn- load-ooapi-phase-for-update [{::ooapi/keys [type id] :as request}]
+  {:pre  [(#{"programme" "course"} type)]
+   :post [(:rio-type %)]}
+  (logging/with-mdc
+    {:ooapi-type type :ooapi-id id}
+    (let [{::ooapi/keys [entity] :as result} (ooapi.loader/load-entities request)]
+      (quick-validate entity type)
+      (assoc result :rio-type (if (and (= "programme" type)
+                                       (= "specification" (:programmeType entity)))
+                                :oe
+                                :ao)))))
 
 ;; in:  {::ooapi/keys [type id entity] :keys [action rio-type institution-name institution-oin institution-schac-home]}
 ;; diff out: {::rio/keys [opleidingscode aangeboden-opleiding-code]}
@@ -198,36 +195,28 @@
 
 ;; in:  {::ooapi/keys [type id entity] :keys [rio-relations action rio-type institution-name institution-oin institution-schac-home] ::rio/keys [opleidingscode aangeboden-opleiding-code]}
 ;; out {:job job :result result :prgspec prgspec}
-(defn- make-updater-soap-phase
-  "Phase definition for creating the soap document.
+(defn- soap-phase-for-update [{:keys [institution-oin] :as job}]
+  {:pre [institution-oin (job :institution-schac-home)]}
+  (let [result  (updated-handler/update-mutation job)
+        prgspec (extract-prgspec-from-result result)]
+    {:job job :result result :prgspec prgspec}))
 
-   Returns function that takes request, and returns map with keys
-   :job (request), :result (::Mutation/mutation-response) and :prgspec (education specification)
-  "
-  []
-  (fn soap-phase [{:keys [institution-oin] :as job}]
-    {:pre [institution-oin (job :institution-schac-home)]}
-    (let [result  (updated-handler/update-mutation job)
-          prgspec (extract-prgspec-from-result result)]
-      {:job job :result result :prgspec prgspec})))
-
-(defn- make-deleter-prune-relations-phase [handlers]
+(defn- make-deleter-prune-relations-phase [handlers rio-config]
   (fn [{::rio/keys [opleidingscode] :keys [institution-oin rio-type] :as request}]
     {:pre [rio-type]}
     (when (and opleidingscode (= :oe rio-type))
-      (relation-handler/delete-relations opleidingscode rio-type institution-oin handlers))
+      (relation-handler/delete-relations opleidingscode rio-type institution-oin (:getter handlers) rio-config))
     request))
 
-(defn- make-deleter-soap-phase []
-  (fn soap-phase [{:keys [institution-oin] :as job}]
-    {:pre [institution-oin (job :institution-schac-home)]}
-    (let [result  (updated-handler/deletion-mutation job)
-          prgspec (extract-prgspec-from-result result)]
-      {:job job :result result :prgspec prgspec})))
+(defn- soap-phase-for-delete [{:keys [institution-oin] :as job}]
+  {:pre [institution-oin (job :institution-schac-home)]}
+  (let [result  (updated-handler/deletion-mutation job)
+        prgspec (extract-prgspec-from-result result)]
+    {:job job :result result :prgspec prgspec}))
 
 ;; in:  {:job job :result result :prgspec prgspec}
 ;; out: {:job job :mutate-result result :prgspec prgspec}
-(defn- make-updater-mutate-rio-phase [{:keys [rio-config]}]
+(defn- make-updater-mutate-rio-phase [rio-config]
   (fn mutate-rio-phase [{:keys [job result prgspec]}]
     {:pre [(s/valid? ::mutation/mutation-response result)]}
     (logging/with-mdc {:soap-action (:action result) :ooapi-id (::ooapi/id job)}
@@ -269,14 +258,15 @@
   one with no subtype and one with subtype variant.
   To perform synchronization, relations are added and deleted in RIO."
   [{:keys [getter] :as handlers} config]
+
   (fn sync-relations-phase [{:keys [job prgspec] :as request}]
     (if (nil? prgspec)
       request
-      (let [{:keys [missing superfluous] :as diff} (relation-handler/relation-mutations prgspec job handlers)
+      (let [{:keys [missing superfluous] :as diff} (relation-handler/relation-mutations prgspec job handlers config)
             {:keys [institution-oin]} job
             {::rio/keys [opleidingscode]} prgspec]
 
-        (relation-handler/mutate-relations! diff job handlers)
+        (relation-handler/mutate-relations! diff job (:rio-config config))
         (rio.helper/blocking-retry (fn in-sync? []
                                      (let [rio-relations (relation-handler/load-relation-data getter opleidingscode institution-oin)
                                            rio-relations-set (set rio-relations)
@@ -298,8 +288,8 @@
                         ex))))))
 
 (defn- make-insert [handlers rio-config]
-  (let [fs [[:preparing      (make-updater-soap-phase)]
-            [:upserting      (make-updater-mutate-rio-phase handlers)]
+  (let [fs [[:preparing      soap-phase-for-update]
+            [:upserting      (make-updater-mutate-rio-phase rio-config)]
             [:confirming     (make-updater-confirm-rio-phase handlers rio-config)]]
         wrapped-fs (map wrap-phase fs)]
     (fn [request]
@@ -309,34 +299,37 @@
         (reduce (fn [req f] (f req)) $ wrapped-fs)
         (:mutate-result $)))))
 
-(defn- make-update [handlers rio-config]
-  (let [fs [[:fetching-ooapi  (make-updater-load-ooapi-phase handlers)]
+(defn- make-update [handlers {:keys [rio-config] :as config}]
+  (let [fs [[:fetching-ooapi  load-ooapi-phase-for-update]
             [:resolving       (make-updater-resolve-phase handlers)]
             [:load-relations  (make-load-relations-phase handlers)]
             [:prune-relations (make-prune-relations-phase handlers rio-config)]
-            [:preparing       (make-updater-soap-phase)]
-            [:upserting       (make-updater-mutate-rio-phase handlers)]
+            [:preparing       soap-phase-for-update]
+            [:upserting       (make-updater-mutate-rio-phase rio-config)]
             [:confirming      (make-updater-confirm-rio-phase handlers rio-config)]
-            [:associating     (make-updater-sync-relations-phase handlers rio-config)]]
+            [:associating     (make-updater-sync-relations-phase handlers config)]]
         wrapped-fs (map wrap-phase fs)]
     (fn [request]
       {:pre [(:institution-oin request)]}
       (as-> request $
+        (merge $ (ooapi.loader/request-gateway-opts config))
         (reduce (fn [req f] (f req)) $ wrapped-fs)
         (merge (:mutate-result $) (select-keys (:job $) [::rio/aangeboden-opleiding-code]))))))
 
-(defn- make-deleter [{:keys [rio-config] :as handlers}]
+(defn- make-deleter [handlers
+                     {:keys [rio-config] :as config}]
   {:pre [rio-config]}
-  (let [fs [[:fetching-ooapi (make-deleter-load-ooapi-phase handlers)]
+  (let [fs [[:fetching-ooapi load-ooapi-phase-for-delete]
             [:resolving      (make-updater-resolve-phase handlers)]
-            [:deleting       (make-deleter-prune-relations-phase handlers)]
-            [:preparing      (make-deleter-soap-phase)]
-            [:deleting       (make-updater-mutate-rio-phase handlers)]
+            [:deleting       (make-deleter-prune-relations-phase handlers rio-config)]
+            [:preparing      soap-phase-for-delete]
+            [:deleting       (make-updater-mutate-rio-phase rio-config)]
             [:confirming     (make-deleter-confirm-rio-phase handlers rio-config)]]
         wrapped-fs (map wrap-phase fs)]
     (fn [request]
       {:pre [(:institution-oin request)]}
       (as-> request $
+        (merge $ (ooapi.loader/request-gateway-opts config))
         (reduce (fn [req f] (f req)) $ wrapped-fs)
         (:mutate-result $)))))
 
@@ -353,10 +346,10 @@
         output (if (nil? ooapi-summary) diff (assoc diff :opleidingseenheidcode rio-code))]
     (merge output (dry-run-status rio-summary ooapi-summary))))
 
-(defn- course-program-dry-run-handler [ooapi-entity {::ooapi/keys [id] :keys [institution-oin] :as request} {:keys [getter ooapi-loader-config]}]
+(defn- course-program-dry-run-handler [ooapi-entity {::ooapi/keys [id] :keys [institution-oin] :as request} {:keys [getter]}]
   (let [rio-obj     (rio.loader/find-aangebodenopleiding id getter institution-oin)
         rio-summary (dry-run/summarize-aangebodenopleiding-xml rio-obj)
-        offering-summary (->> (ooapi.loader/load-offerings ooapi-loader-config request)
+        offering-summary (->> (ooapi.loader/load-offerings request)
                               (map dry-run/summarize-offering)
                               (sort-by :cohortcode)
                               vec)
@@ -366,48 +359,39 @@
         output (if (nil? ooapi-summary) diff (assoc diff :aangebodenOpleidingCode rio-code))]
     (merge output (dry-run-status rio-summary ooapi-summary))))
 
-(defn- not-found? [obj]
-  (= http-status/not-found (:status obj)))
-
-(defn- safe-loader [f]
+(defn- try-load-entity
+  "Load an OOAPI entity, returning nil for 404 responses."
+  [request]
   (try
-    (f)
+    (ooapi.loader/ooapi-http-loader request)
     (catch Exception ex
-      (if (not-found? (ex-data ex))
-        (ex-data ex)
+      (when (not= http-status/not-found (:status (ex-data ex)))
         (throw ex)))))
 
-(defn- make-dry-runner [{:keys [rio-config ooapi-loader-config] :as handlers}]
-  {:pre [rio-config]}
+(defn- make-dry-runner [handlers config]
   (fn [{::ooapi/keys [type] :as request}]
     {:pre [(:institution-oin request)]}
-    (let [ooapi-entity (safe-loader (fn [] (ooapi.loader/ooapi-http-load request ooapi-loader-config)))
-          value (if (not-found? ooapi-entity)
-                  {:status "error"}
-                  (let [handler (if (or (= type "course")
-                                        (not= "specification" (:programmeType ooapi-entity)))
-                                  course-program-dry-run-handler
-                                  prgspec-dry-run-handler)]
-                    (handler ooapi-entity request handlers)))]
+    (let [request (merge request (ooapi.loader/request-gateway-opts config))
+          entity  (try-load-entity request)
+          value   (if-not entity
+                    {:status "error"}
+                    (let [handler (if (and (= type "programme")
+                                           (= "specification" (:programmeType entity)))
+                                    prgspec-dry-run-handler
+                                    course-program-dry-run-handler)]
+                      (handler entity request handlers)))]
       {:dry-run value})))
 
 (defn make-handlers
-  [{:keys [rio-config
-           gateway-root-url
-           gateway-credentials]}]
+  [{:keys [rio-config] :as config}]
   {:pre [(:recipient-oin rio-config)]}
   (let [resolver     (rio.loader/make-resolver rio-config)
         getter       (rio.loader/make-getter rio-config)
-        ooapi-loader-config (ooapi.loader/make-ooapi-http-loader-config gateway-root-url
-                                                                        gateway-credentials
-                                                                        rio-config)
-        handlers     {:ooapi-loader-config ooapi-loader-config
-                      :rio-config          rio-config
-                      :getter              getter
+        handlers     {:getter              getter
                       :resolver            resolver}
-        update!      (make-update handlers rio-config)
-        delete!      (make-deleter handlers)
+        update!      (make-update handlers config)
+        delete!      (make-deleter handlers config)
         insert!      (make-insert handlers rio-config)
-        dry-run!     (make-dry-runner handlers)
+        dry-run!     (make-dry-runner handlers config)
         link!        (link/make-linker rio-config getter)]
     (assoc handlers :update! update!, :delete! delete!, :insert! insert!, :dry-run! dry-run!, :link! link!)))

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/commands/processing.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/commands/processing.clj
@@ -68,7 +68,7 @@
 
 ;; Only function of this phase is to load programmes in order to distinguish
 ;; programmes from programme-specifications, which are different object in RIO
-(defn- make-deleter-load-ooapi-phase [{:keys [ooapi-loader]}]
+(defn- make-deleter-load-ooapi-phase [{:keys [ooapi-loader-config]}]
   (fn load-ooapi-phase [{::ooapi/keys [type id] :as request}]
     {:pre  [(#{"programme" "course"} type)]
      :post [(:rio-type %)]}
@@ -76,7 +76,7 @@
       (assoc request :rio-type :ao)
       (logging/with-mdc
         {:ooapi-type type :ooapi-id id}
-        (let [entity (ooapi-loader request)]
+        (let [entity (ooapi.loader/ooapi-http-load request ooapi-loader-config)]
           (assoc request :rio-type (if (and (= "programme" type)
                                             (= "specification" (:programmeType entity)))
                                      :oe
@@ -85,13 +85,13 @@
 ;; in:  {::ooapi/keys [type id] :keys [action institution-name institution-oin institution-schac-home]}
 ;; diff out: {:keys [rio-type] ::ooapi/keys [entity]}
 :nl.surf.eduhub-rio-mapper.v6.specs.ooapi/specification-type
-(defn- make-updater-load-ooapi-phase [{:keys [ooapi-loader]}]
+(defn- make-updater-load-ooapi-phase [{:keys [ooapi-loader-config]}]
   (fn load-ooapi-phase [{::ooapi/keys [type id] :as request}]
     {:pre  [(#{"programme" "course"} type)]
      :post [(:rio-type %)]}
     (logging/with-mdc
       {:ooapi-type type :ooapi-id id}
-      (let [{::ooapi/keys [entity] :as result} (ooapi.loader/load-entities ooapi-loader request)]
+      (let [{::ooapi/keys [entity] :as result} (ooapi.loader/load-entities ooapi-loader-config request)]
         (quick-validate entity type)
         (assoc result :rio-type (if (and (= "programme" type)
                                          (= "specification" (:programmeType entity)))
@@ -353,10 +353,10 @@
         output (if (nil? ooapi-summary) diff (assoc diff :opleidingseenheidcode rio-code))]
     (merge output (dry-run-status rio-summary ooapi-summary))))
 
-(defn- course-program-dry-run-handler [ooapi-entity {::ooapi/keys [id] :keys [institution-oin] :as request} {:keys [getter ooapi-loader]}]
+(defn- course-program-dry-run-handler [ooapi-entity {::ooapi/keys [id] :keys [institution-oin] :as request} {:keys [getter ooapi-loader-config]}]
   (let [rio-obj     (rio.loader/find-aangebodenopleiding id getter institution-oin)
         rio-summary (dry-run/summarize-aangebodenopleiding-xml rio-obj)
-        offering-summary (->> (ooapi.loader/load-offerings ooapi-loader request)
+        offering-summary (->> (ooapi.loader/load-offerings ooapi-loader-config request)
                               (map dry-run/summarize-offering)
                               (sort-by :cohortcode)
                               vec)
@@ -377,11 +377,11 @@
         (ex-data ex)
         (throw ex)))))
 
-(defn- make-dry-runner [{:keys [rio-config ooapi-loader] :as handlers}]
+(defn- make-dry-runner [{:keys [rio-config ooapi-loader-config] :as handlers}]
   {:pre [rio-config]}
   (fn [{::ooapi/keys [type] :as request}]
     {:pre [(:institution-oin request)]}
-    (let [ooapi-entity (safe-loader (fn [] (ooapi-loader request)))
+    (let [ooapi-entity (safe-loader (fn [] (ooapi.loader/ooapi-http-load request ooapi-loader-config)))
           value (if (not-found? ooapi-entity)
                   {:status "error"}
                   (let [handler (if (or (= type "course")
@@ -398,13 +398,13 @@
   {:pre [(:recipient-oin rio-config)]}
   (let [resolver     (rio.loader/make-resolver rio-config)
         getter       (rio.loader/make-getter rio-config)
-        ooapi-loader (ooapi.loader/make-ooapi-http-loader gateway-root-url
-                                                          gateway-credentials
-                                                          rio-config)
-        handlers     {:ooapi-loader ooapi-loader
-                      :rio-config   rio-config
-                      :getter       getter
-                      :resolver     resolver}
+        ooapi-loader-config (ooapi.loader/make-ooapi-http-loader-config gateway-root-url
+                                                                        gateway-credentials
+                                                                        rio-config)
+        handlers     {:ooapi-loader-config ooapi-loader-config
+                      :rio-config          rio-config
+                      :getter              getter
+                      :resolver            resolver}
         update!      (make-update handlers rio-config)
         delete!      (make-deleter handlers)
         insert!      (make-insert handlers rio-config)

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/ooapi/loader.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/ooapi/loader.clj
@@ -160,15 +160,12 @@
 ;; It expects the request to contain ::ooapi/root-url,
 ;; ::ooapi/id, ::ooapi/type, :gateway-credentials,
 ;; institution-schac-home
-(def ^:private ooapi-http-loader-fn
+(def ooapi-http-loader
   (-> http-utils/send-http-request
       wrap-ooapi-envelop
       wrap-response-validator
       wrap-ooapi-request->ring-request
       wrap-pagination))
-
-(defn ooapi-http-loader [request]
-  (ooapi-http-loader-fn request))
 
 (defn ooapi-file-loader
   [{::ooapi/keys [type id]}]

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/ooapi/loader.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/ooapi/loader.clj
@@ -155,6 +155,16 @@
           response)
         response))))
 
+(defn wrap-gateway-config [handler]
+  (fn [request]
+    (let [gateway-config (when-let [{:keys [rio-config gateway-root-url gateway-credentials]} (:config request)]
+                           {::ooapi/root-url gateway-root-url
+                            :gateway-credentials gateway-credentials
+                            :connection-timeout (:connection-timeout-millis rio-config)})]
+      (-> request
+          (merge gateway-config)
+          handler))))
+
 ;; This function fetches OOAPI data over http.
 ;;
 ;; It expects the request to contain ::ooapi/root-url,
@@ -165,7 +175,8 @@
       wrap-ooapi-envelop
       wrap-response-validator
       wrap-ooapi-request->ring-request
-      wrap-pagination))
+      wrap-pagination
+      wrap-gateway-config))
 
 (defn ooapi-file-loader
   [{::ooapi/keys [type id]}]
@@ -181,11 +192,6 @@
              ::ooapi/type (str type "-offerings"))
       (ooapi-http-loader)
       :items))
-
-(defn request-gateway-opts [{:keys [rio-config gateway-root-url gateway-credentials]}]
-  {::ooapi/root-url gateway-root-url
-   :gateway-credentials gateway-credentials
-   :connection-timeout (:connection-timeout-millis rio-config)})
 
 (defn load-entities
   "Loads ooapi entity, including associated offerings and education specification, if applicable."

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/ooapi/loader.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/ooapi/loader.clj
@@ -56,6 +56,7 @@
   (fn [{::ooapi/keys [root-url type id]
         :keys        [institution-schac-home gateway-credentials connection-timeout page]
         :as          request}]
+    {:pre [type]}
     (let [url (str root-url (ooapi-type->path type id page))
           uri (string/replace url #"\?.*" "")]
       (:body (handler (merge request
@@ -166,18 +167,24 @@
       wrap-ooapi-request->ring-request
       wrap-pagination))
 
-(defn make-ooapi-http-loader
+(defn ooapi-http-load [request {:keys [root-url gateway-credentials connection-timeout-millis]}]
+  {:pre [root-url]}
+  (let [request (assoc request
+                       ::ooapi/root-url root-url
+                       :gateway-credentials gateway-credentials
+                       :connection-timeout connection-timeout-millis)]
+    (ooapi-http-loader request)))
+
+(defn make-ooapi-http-loader-config
   "Returns an ooapi-loader function for the given configuration.
 
   The returned loader takes a map with ::ooapi/id, ::ooapi/type
   attributes"
   [root-url credentials rio-config]
-  (fn wrapped-ooapi-http-loader [context]
-    (let [request (assoc context
-                         ::ooapi/root-url root-url
-                         :gateway-credentials credentials
-                         :connection-timeout (:connection-timeout-millis rio-config))]
-      (ooapi-http-loader request))))
+  {:pre [root-url]}
+  {:root-url root-url
+   :gateway-credentials credentials
+   :connection-timeout-millis (:connection-timeout-millis rio-config)})
 
 (defn ooapi-file-loader
   [{::ooapi/keys [type id]}]
@@ -186,27 +193,27 @@
     (json/read-str (slurp path) :key-fn keyword)))
 
 (defn load-offerings
-  [loader {::ooapi/keys [id type] :as request}]
+  [loader-config {::ooapi/keys [id type] :as request}]
   {:pre [(#{"programme" "course"} type)]}
   (-> request
       (assoc ::ooapi/id id
              ::ooapi/type (str type "-offerings"))
-      (loader)
+      (ooapi-http-load loader-config)
       :items))
 
 (defn load-entities
   "Loads ooapi entity, including associated offerings and education specification, if applicable."
-  [loader {::ooapi/keys [type] :as request}]
-  {:pre  [(#{"programme" "course"} type)]
-   :post [(some? (::ooapi/entity %))
+  [loader-config request]
+  {:post [(some? (::ooapi/entity %))
           (not-empty (::ooapi/entity %))]}
-  (let [entity                  (loader request)
+  (let [type                    (::ooapi/type request)
+        entity                  (ooapi-http-load request loader-config)
         consumer                (:consumer entity)
         joint-programme?          (= "true" (str (:jointProgramme consumer)))
         ;; load offerings unless prgspec (type = programme and programmeType = specification)
         offerings               (when (or (not= type "programme")
                                           (not= "specification" (:programmeType entity)))
-                                  (load-offerings loader request))
+                                  (load-offerings loader-config request))
         prgspec-type            (cond
                                   joint-programme?
                                   "programme"
@@ -218,7 +225,7 @@
                                   (-> request
                                       (assoc ::ooapi/type "programme"
                                              ::ooapi/id (:specificationId consumer))
-                                      (loader)
+                                      (ooapi-http-load loader-config)
                                       (get-in [:consumer :specificationType])))]
     (cond-> request
       joint-programme?

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/ooapi/loader.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/ooapi/loader.clj
@@ -34,7 +34,7 @@
 
 (defn- ooapi-type->path [ooapi-type id page]
   {:pre  [(string? ooapi-type)
-          (or (#{"programme" "programme-offerings" "course" "course-offerings"} ooapi-type) (prn ooapi-type))]}
+          (#{"programme" "programme-offerings" "course" "course-offerings"} ooapi-type)]}
   (if id
     (let [page-suffix (if page (str "&pageNumber=" page) "")
           path        (case ooapi-type
@@ -135,7 +135,7 @@
                          :response response})))
       response)))
 
-(def max-pages 50)
+(def ^:private max-pages 50)
 
 (defn- wrap-pagination
   "Middleware for fetching paged items.
@@ -160,31 +160,15 @@
 ;; It expects the request to contain ::ooapi/root-url,
 ;; ::ooapi/id, ::ooapi/type, :gateway-credentials,
 ;; institution-schac-home
-(def ^:private ooapi-http-loader
+(def ^:private ooapi-http-loader-fn
   (-> http-utils/send-http-request
       wrap-ooapi-envelop
       wrap-response-validator
       wrap-ooapi-request->ring-request
       wrap-pagination))
 
-(defn ooapi-http-load [request {:keys [root-url gateway-credentials connection-timeout-millis]}]
-  {:pre [root-url]}
-  (let [request (assoc request
-                       ::ooapi/root-url root-url
-                       :gateway-credentials gateway-credentials
-                       :connection-timeout connection-timeout-millis)]
-    (ooapi-http-loader request)))
-
-(defn make-ooapi-http-loader-config
-  "Returns an ooapi-loader function for the given configuration.
-
-  The returned loader takes a map with ::ooapi/id, ::ooapi/type
-  attributes"
-  [root-url credentials rio-config]
-  {:pre [root-url]}
-  {:root-url root-url
-   :gateway-credentials credentials
-   :connection-timeout-millis (:connection-timeout-millis rio-config)})
+(defn ooapi-http-loader [request]
+  (ooapi-http-loader-fn request))
 
 (defn ooapi-file-loader
   [{::ooapi/keys [type id]}]
@@ -193,27 +177,32 @@
     (json/read-str (slurp path) :key-fn keyword)))
 
 (defn load-offerings
-  [loader-config {::ooapi/keys [id type] :as request}]
+  [{::ooapi/keys [id type] :as request}]
   {:pre [(#{"programme" "course"} type)]}
   (-> request
       (assoc ::ooapi/id id
              ::ooapi/type (str type "-offerings"))
-      (ooapi-http-load loader-config)
+      (ooapi-http-loader)
       :items))
+
+(defn request-gateway-opts [{:keys [rio-config gateway-root-url gateway-credentials]}]
+  {::ooapi/root-url gateway-root-url
+   :gateway-credentials gateway-credentials
+   :connection-timeout (:connection-timeout-millis rio-config)})
 
 (defn load-entities
   "Loads ooapi entity, including associated offerings and education specification, if applicable."
-  [loader-config request]
+  [request]
   {:post [(some? (::ooapi/entity %))
           (not-empty (::ooapi/entity %))]}
   (let [type                    (::ooapi/type request)
-        entity                  (ooapi-http-load request loader-config)
+        entity                  (ooapi-http-loader request)
         consumer                (:consumer entity)
         joint-programme?          (= "true" (str (:jointProgramme consumer)))
         ;; load offerings unless prgspec (type = programme and programmeType = specification)
         offerings               (when (or (not= type "programme")
                                           (not= "specification" (:programmeType entity)))
-                                  (load-offerings loader-config request))
+                                  (load-offerings request))
         prgspec-type            (cond
                                   joint-programme?
                                   "programme"
@@ -225,7 +214,7 @@
                                   (-> request
                                       (assoc ::ooapi/type "programme"
                                              ::ooapi/id (:specificationId consumer))
-                                      (ooapi-http-load loader-config)
+                                      (ooapi-http-loader)
                                       (get-in [:consumer :specificationType])))]
     (cond-> request
       joint-programme?

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/rio/relation_handler.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/rio/relation_handler.clj
@@ -139,10 +139,10 @@
                             (assoc entity ::rio/opleidingscode rio-code))))
          load-prgspec (fn load-prgspec [id]
                         {:pre [id]}
-                        (when-let [es (ooapi.loader/ooapi-http-loader (merge (ooapi.loader/request-gateway-opts config)
-                                                                             {::ooapi/type            "programme"
-                                                                              ::ooapi/id              id
-                                                                              :institution-schac-home institution-schac-home}))]
+                        (when-let [es (ooapi.loader/ooapi-http-loader {::ooapi/type            "programme"
+                                                                       ::ooapi/id              id
+                                                                       :institution-schac-home institution-schac-home
+                                                                       :config                 config})]
                           (add-rio-code es)))
          prgspec (add-rio-code prgspec)
          actual (load-relation-data getter (::rio/opleidingscode prgspec) institution-oin)

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/rio/relation_handler.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/rio/relation_handler.clj
@@ -107,23 +107,30 @@
            ::rio/type             "opleidingsrelatiesBijOpleidingseenheid"
            ::rio/opleidingscode   opleidingscode}))
 
-(defn delete-relations [opleidingscode rio-type institution-oin {:keys [rio-config getter]}]
-  {:pre [(s/valid? ::rio/opleidingscode opleidingscode)]}
+(defn delete-relations [opleidingscode rio-type institution-oin getter rio-config]
+  {:pre [(s/valid? ::rio/opleidingscode opleidingscode) (:recipient-oin rio-config)]}
   (when (= rio-type :oe)
     (doseq [rel (load-relation-data getter opleidingscode institution-oin)]
       (-> (relation-mutation :delete institution-oin rel)
           (mutator/mutate! rio-config)))))
 
 (defn relation-mutations
-  ([prgspec job handlers]
+  ([prgspec job handlers config]
    {:pre [prgspec]}
    (relation-mutations prgspec
                        :programmeId
                        (-> prgspec :consumer :variantOf)
                        (-> prgspec :consumer :variantIds)
                        job
-                       handlers))
-  ([prgspec primary-key variant-of variants {:keys [institution-oin institution-schac-home] :as _job} {:keys [getter resolver ooapi-loader-config]}]
+                       handlers
+                       config))
+  ([prgspec
+    primary-key
+    variant-of variants
+    {:keys [institution-oin institution-schac-home] :as _job}
+    {:keys [getter resolver] :as _handlers}
+    config]
+
    {:pre [prgspec]}
    (let [add-rio-code (fn add-rio-code [entity]
                         (if (::rio/opleidingscode entity)
@@ -132,10 +139,10 @@
                             (assoc entity ::rio/opleidingscode rio-code))))
          load-prgspec (fn load-prgspec [id]
                         {:pre [id]}
-                        (when-let [es (ooapi.loader/ooapi-http-load {::ooapi/type            "programme"
-                                                                     ::ooapi/id              id
-                                                                     :institution-schac-home institution-schac-home}
-                                                                    ooapi-loader-config)]
+                        (when-let [es (ooapi.loader/ooapi-http-loader (merge (ooapi.loader/request-gateway-opts config)
+                                                                             {::ooapi/type            "programme"
+                                                                              ::ooapi/id              id
+                                                                              :institution-schac-home institution-schac-home}))]
                           (add-rio-code es)))
          prgspec (add-rio-code prgspec)
          actual (load-relation-data getter (::rio/opleidingscode prgspec) institution-oin)
@@ -146,7 +153,7 @@
      (relation-differences prgspec rel-dir entity actual))))
 
 (defn mutate-relations!
-  [{:keys [missing superfluous] :as diff} {:keys [institution-oin] :as _job} {:keys [rio-config] :as _handlers}]
+  [{:keys [missing superfluous] :as diff} {:keys [institution-oin] :as _job} rio-config]
   {:pre [institution-oin (:recipient-oin rio-config)]}
   (let [mutator (fn [rel op] (-> (relation-mutation op institution-oin rel)
                                  (mutator/mutate! rio-config)))]

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/rio/relation_handler.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/rio/relation_handler.clj
@@ -23,6 +23,7 @@
             [nl.surf.eduhub-rio-mapper.specs.mutation :as-alias mutation]
             [nl.surf.eduhub-rio-mapper.specs.ooapi :as ooapi]
             [nl.surf.eduhub-rio-mapper.specs.rio :as rio]
+            [nl.surf.eduhub-rio-mapper.v6.ooapi.loader :as ooapi.loader]
             [nl.surf.eduhub-rio-mapper.v6.specs.relations :as relations]))
 
 (defn- narrow-valid-daterange
@@ -122,7 +123,7 @@
                        (-> prgspec :consumer :variantIds)
                        job
                        handlers))
-  ([prgspec primary-key variant-of variants {:keys [institution-oin institution-schac-home] :as _job} {:keys [getter resolver ooapi-loader]}]
+  ([prgspec primary-key variant-of variants {:keys [institution-oin institution-schac-home] :as _job} {:keys [getter resolver ooapi-loader-config]}]
    {:pre [prgspec]}
    (let [add-rio-code (fn add-rio-code [entity]
                         (if (::rio/opleidingscode entity)
@@ -131,9 +132,10 @@
                             (assoc entity ::rio/opleidingscode rio-code))))
          load-prgspec (fn load-prgspec [id]
                         {:pre [id]}
-                        (when-let [es (ooapi-loader {::ooapi/type            "programme"
-                                                     ::ooapi/id              id
-                                                     :institution-schac-home institution-schac-home})]
+                        (when-let [es (ooapi.loader/ooapi-http-load {::ooapi/type            "programme"
+                                                                     ::ooapi/id              id
+                                                                     :institution-schac-home institution-schac-home}
+                                                                    ooapi-loader-config)]
                           (add-rio-code es)))
          prgspec (add-rio-code prgspec)
          actual (load-relation-data getter (::rio/opleidingscode prgspec) institution-oin)

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/dry_run_test.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/dry_run_test.clj
@@ -36,10 +36,7 @@
   (let [vcr    (vcr.helper/make-vcr)
         config (helper/make-test-config)
         client-info (clients-info/client-info (:clients config) "rio-mapper-dev.jomco.nl")
-        rio-config (:rio-config config)
-        handlers (processing/make-handlers {:rio-config rio-config
-                                            :gateway-root-url (:gateway-root-url config)
-                                            :gateway-credentials (:gateway-credentials config)})
+        handlers (processing/make-handlers config)
         dry-run! (:dry-run! handlers)]
 
     (testing "education-specifications"
@@ -144,8 +141,8 @@
         (let [result (dry-run! (assoc client-info
                                       ::ooapi/id "44444444-dfc3-4a30-874e-0b70db15638a"
                                       ::ooapi/type "course"))]
-          (is (= {:status "error"}
-                 (:dry-run result))))))
+          (is (= {:dry-run {:status "error"}}
+                 result)))))
 
     (testing "courses"
       (binding [http-utils/*vcr* (vcr "test-v6/fixtures/aangebodenopl-dryrun" 3 "finder")]

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/interaction_test.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/interaction_test.clj
@@ -116,10 +116,7 @@
                                (config/make-config env)
                                (assoc-in (helper/make-test-config) [:rio-config :rio-retry-attempts-seconds] [1 1 1 1]))
         client-info          (clients-info/client-info (:clients config) "rio-mapper-dev.jomco.nl")
-        rio-config           (:rio-config config)
-        handlers             (processing/make-handlers {:rio-config rio-config
-                                                        :gateway-root-url (:gateway-root-url config)
-                                                        :gateway-credentials (:gateway-credentials config)})
+        handlers             (processing/make-handlers config)
         prgspec-parent-id    (entity-name-to-id "programmes/specification-interaction-prgspec-parent")
         prgspec-child-id     (entity-name-to-id "programmes/specification-interaction-prgspec-child")
         program-id           (entity-name-to-id "programmes/interaction-programme-some")
@@ -203,10 +200,6 @@
         config       (if (= vcr.helper/vcr-mode :record)
                        (config/make-config env)
                        (helper/make-test-config))
-        ooapi-loader-config (ooapi.loader/make-ooapi-http-loader-config (:gateway-root-url config)
-                                                                        (:gateway-credentials config)
-                                                                        config)
-
         client-info  (clients-info/client-info (:clients config) "rio-mapper-dev.jomco.nl")]
     (testing "programme"
       (let [request      {::ooapi/root-url (URI. "https://rio-mapper-dev.jomco.nl/")
@@ -214,8 +207,8 @@
                           ::ooapi/id       (entity-name-to-id "programmes/v5-program")
                           :gateway-credentials (:gateway-credentials config)}]
         (binding [http-utils/*vcr* (vcr "test-v6/fixtures/vcr/ooapi-loader" 2 "programme")]
-          (let [ex (is (thrown? ExceptionInfo (-> (merge client-info request)
-                                                  (ooapi.loader/ooapi-http-load ooapi-loader-config))))]
+          (let [ex (is (thrown? ExceptionInfo (-> (merge request client-info (ooapi.loader/request-gateway-opts config))
+                                                  (ooapi.loader/ooapi-http-loader))))]
             (is (= {:issue "schema-validation-error"
                     :canonical-schema-path ["components" "schemas" "ProgrammeId" "required"]}
                    (select-keys (first (:issues (ex-data ex)))
@@ -227,5 +220,5 @@
                      ::ooapi/id       (entity-name-to-id "programmes/interaction-programme-some")
                      :gateway-credentials (:gateway-credentials config)}]
         (binding [http-utils/*vcr* (vcr "test-v6/fixtures/vcr/ooapi-loader" 1 "offering")]
-          (let [items (:items (ooapi.loader/ooapi-http-load (merge client-info request)  ooapi-loader-config))]
+          (let [items (:items (ooapi.loader/ooapi-http-loader (merge request client-info (ooapi.loader/request-gateway-opts config))))]
             (is (= 3 (count items)))))))))

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/interaction_test.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/interaction_test.clj
@@ -203,9 +203,9 @@
         config       (if (= vcr.helper/vcr-mode :record)
                        (config/make-config env)
                        (helper/make-test-config))
-        ooapi-loader (ooapi.loader/make-ooapi-http-loader (:gateway-root-url config)
-                                                          (:gateway-credentials config)
-                                                          config)
+        ooapi-loader-config (ooapi.loader/make-ooapi-http-loader-config (:gateway-root-url config)
+                                                                        (:gateway-credentials config)
+                                                                        config)
 
         client-info  (clients-info/client-info (:clients config) "rio-mapper-dev.jomco.nl")]
     (testing "programme"
@@ -214,7 +214,8 @@
                           ::ooapi/id       (entity-name-to-id "programmes/v5-program")
                           :gateway-credentials (:gateway-credentials config)}]
         (binding [http-utils/*vcr* (vcr "test-v6/fixtures/vcr/ooapi-loader" 2 "programme")]
-          (let [ex (is (thrown? ExceptionInfo (-> (merge client-info request) ooapi-loader)))]
+          (let [ex (is (thrown? ExceptionInfo (-> (merge client-info request)
+                                                  (ooapi.loader/ooapi-http-load ooapi-loader-config))))]
             (is (= {:issue "schema-validation-error"
                     :canonical-schema-path ["components" "schemas" "ProgrammeId" "required"]}
                    (select-keys (first (:issues (ex-data ex)))
@@ -226,5 +227,5 @@
                      ::ooapi/id       (entity-name-to-id "programmes/interaction-programme-some")
                      :gateway-credentials (:gateway-credentials config)}]
         (binding [http-utils/*vcr* (vcr "test-v6/fixtures/vcr/ooapi-loader" 1 "offering")]
-          (let [items (:items (ooapi-loader (merge client-info request)))]
+          (let [items (:items (ooapi.loader/ooapi-http-load (merge client-info request)  ooapi-loader-config))]
             (is (= 3 (count items)))))))))

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/interaction_test.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/interaction_test.clj
@@ -207,8 +207,7 @@
                           ::ooapi/id       (entity-name-to-id "programmes/v5-program")
                           :gateway-credentials (:gateway-credentials config)}]
         (binding [http-utils/*vcr* (vcr "test-v6/fixtures/vcr/ooapi-loader" 2 "programme")]
-          (let [ex (is (thrown? ExceptionInfo (-> (merge request client-info (ooapi.loader/request-gateway-opts config))
-                                                  (ooapi.loader/ooapi-http-loader))))]
+          (let [ex (is (thrown? ExceptionInfo (ooapi.loader/ooapi-http-loader (merge request client-info {:config config}))))]
             (is (= {:issue "schema-validation-error"
                     :canonical-schema-path ["components" "schemas" "ProgrammeId" "required"]}
                    (select-keys (first (:issues (ex-data ex)))
@@ -220,5 +219,5 @@
                      ::ooapi/id       (entity-name-to-id "programmes/interaction-programme-some")
                      :gateway-credentials (:gateway-credentials config)}]
         (binding [http-utils/*vcr* (vcr "test-v6/fixtures/vcr/ooapi-loader" 1 "offering")]
-          (let [items (:items (ooapi.loader/ooapi-http-loader (merge request client-info (ooapi.loader/request-gateway-opts config))))]
+          (let [items (:items (ooapi.loader/ooapi-http-loader (merge request client-info {:config config})))]
             (is (= 3 (count items)))))))))

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/mapper_integration_test.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/mapper_integration_test.clj
@@ -54,15 +54,16 @@
 
 (defn- simulate-upsert [ooapi-loader xml-response ooapi-type rio-type]
   {:pre [(some? xml-response) rio-type]}
-  (binding [client/request (constantly {:status 200 :body xml-response})]
-    (let [handle-updated #(helper/test-handler % test-resolver ooapi-loader)
-          mutation       (handle-updated {::ooapi/id ooapi-id
-                                          ::ooapi/type ooapi-type
-                                          :rio-type rio-type
-                                          :institution-oin institution-oin
-                                          ::ooapi-v6/specification-type "programme"})]
-      {:result (mutator/mutate! mutation (:rio-config config))
-       :mutation mutation})))
+  (helper/with-ooapi-loader ooapi-loader
+    (binding [client/request (constantly {:status 200 :body xml-response})]
+      (let [handle-updated #(helper/test-handler % test-resolver)
+            mutation       (handle-updated {::ooapi/id ooapi-id
+                                            ::ooapi/type ooapi-type
+                                            :rio-type rio-type
+                                            :institution-oin institution-oin
+                                            ::ooapi-v6/specification-type "programme"})]
+        {:result (mutator/mutate! mutation (:rio-config config))
+         :mutation mutation}))))
 
 (defn- simulate-delete [ooapi-type rio-type xml-response]
   {:pre [(some? xml-response)]}
@@ -82,12 +83,12 @@
                     :offerings      "fixtures/ooapi/integration-program-offerings-0.json"})
 
 (deftest test-handle-updated-prgspec-0
-  (let [actual (helper/test-handler {::ooapi/id   ooapi-id
-                                     ::ooapi/type "programme"
-                                     :rio-type :oe
-                                     :institution-oin institution-oin}
-                                    test-resolver
-                                    (mock-ooapi-loader prgspec-req-0))]
+  (let [actual (helper/with-ooapi-loader (mock-ooapi-loader prgspec-req-0)
+                 (helper/test-handler {::ooapi/id   ooapi-id
+                                       ::ooapi/type "programme"
+                                       :rio-type :oe
+                                       :institution-oin institution-oin}
+                                      test-resolver))]
     (is (nil? (:errors actual)))
     (is (= "EN TRANSLATION: Computer Science" (-> actual :ooapi :name first :value)))))
 

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/relation_handler_test.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/relation_handler_test.clj
@@ -110,7 +110,6 @@
                                     3 "3234O1234"
                                     4 "4234O1234"
                                     5 "5234O1234"))
-                  :ooapi-loader-config nil
                   ;; actual relations
                   :getter       (fn [{::rio/keys [opleidingscode]}]
                                   (case opleidingscode

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/relation_handler_test.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/relation_handler_test.clj
@@ -27,7 +27,8 @@
    [nl.surf.eduhub-rio-mapper.specs.rio :as rio]
    [nl.surf.eduhub-rio-mapper.utils.keystore :as keystore]
    [nl.surf.eduhub-rio-mapper.utils.soap :as soap]
-   [nl.surf.eduhub-rio-mapper.v6.rio.relation-handler :as rh]))
+   [nl.surf.eduhub-rio-mapper.v6.rio.relation-handler :as rh]
+   [nl.surf.eduhub-rio-mapper.v6.test-helper :as helper]))
 
 (def education-specification (-> "fixtures/ooapi/education-specification.json"
                                  io/resource
@@ -109,7 +110,7 @@
                                     3 "3234O1234"
                                     4 "4234O1234"
                                     5 "5234O1234"))
-                  :ooapi-loader (fn [{::ooapi/keys [id]}] (loader id))
+                  :ooapi-loader-config nil
                   ;; actual relations
                   :getter       (fn [{::rio/keys [opleidingscode]}]
                                   (case opleidingscode
@@ -125,22 +126,24 @@
                                                  "test/keystore.jks"
                                                  "xxxxxx"
                                                  "test-surf")}}]
-    (binding [client/request (constantly {:status 200 :body (slurp "test-v6/fixtures/rio/create-relation.xml")})]
-      (testing "child with one parent"
-        (let [{:keys [missing superfluous]} (update-relations (loader 1) job handlers)]
-          (is (empty? superfluous))
-          (is (= missing #{{:valid-from "2022-01-01", :valid-to nil, :opleidingseenheidcodes #{"2234O1234" "1234O1234"}}}))))
+    (helper/with-ooapi-loader (fn [{::ooapi/keys [id]}]
+                                (loader id))
+      (binding [client/request (constantly {:status 200 :body (slurp "test-v6/fixtures/rio/create-relation.xml")})]
+        (testing "child with one parent"
+          (let [{:keys [missing superfluous]} (update-relations (loader 1) job handlers)]
+            (is (empty? superfluous))
+            (is (= missing #{{:valid-from "2022-01-01", :valid-to nil, :opleidingseenheidcodes #{"2234O1234" "1234O1234"}}}))))
 
-      (testing "parent with one child"
-        (let [{:keys [missing superfluous]} (update-relations (loader 2) job handlers)]
-          (is (empty? superfluous))
-          (is (= missing #{{:valid-from "2022-01-01", :valid-to nil, :opleidingseenheidcodes #{"2234O1234" "1234O1234"}}}))))
+        (testing "parent with one child"
+          (let [{:keys [missing superfluous]} (update-relations (loader 2) job handlers)]
+            (is (empty? superfluous))
+            (is (= missing #{{:valid-from "2022-01-01", :valid-to nil, :opleidingseenheidcodes #{"2234O1234" "1234O1234"}}}))))
 
-      (testing "parent with two children"
-        (let [{:keys [missing superfluous]} (update-relations (loader 3) job handlers)]
-          (is (empty? superfluous))
-          (is (= missing #{{:valid-from "2022-01-01", :valid-to nil, :opleidingseenheidcodes #{"3234O1234" "4234O1234"}}
-                           {:valid-from "2022-01-01", :valid-to nil, :opleidingseenheidcodes #{"3234O1234" "5234O1234"}}})))))))
+        (testing "parent with two children"
+          (let [{:keys [missing superfluous]} (update-relations (loader 3) job handlers)]
+            (is (empty? superfluous))
+            (is (= missing #{{:valid-from "2022-01-01", :valid-to nil, :opleidingseenheidcodes #{"3234O1234" "4234O1234"}}
+                             {:valid-from "2022-01-01", :valid-to nil, :opleidingseenheidcodes #{"3234O1234" "5234O1234"}}}))))))))
 
 (deftest test-relation-mutation
   (testing "Valid call to delete relation"

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/relation_handler_test.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/relation_handler_test.clj
@@ -93,8 +93,8 @@
   [prgspec job handlers]
   (when prgspec
     (-> prgspec
-        (rh/relation-mutations job handlers)
-        (rh/mutate-relations! job handlers))))
+        (rh/relation-mutations job handlers nil)
+        (rh/mutate-relations! job (:rio-config handlers)))))
 
 (deftest test-mutate-relation
   (let [job      {:institution-schac-home "a" :institution-oin "b"}

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/rio_test.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/rio_test.clj
@@ -261,7 +261,7 @@
 (defn- test-loader [id ooapi-type]
   (helper/with-ooapi-loader ooapi.loader/ooapi-file-loader
     (->> {::ooapi/id id ::ooapi/type ooapi-type}
-         (ooapi.loader/load-entities nil)
+         (ooapi.loader/load-entities)
          ::ooapi/entity)))
 
 (deftest to-rio-obj
@@ -454,7 +454,6 @@
 
              (helper/with-ooapi-loader mode-of-delivery-loader
                (-> (ooapi.loader/load-entities
-                    nil
                     {::ooapi/id "20010000-0000-0000-0000-000000000000" ::ooapi/type "programme"})
                    ::ooapi/entity
                    (aangeboden-opl/->aangeboden-opleiding :programme "1234O1234" {::ooapi-v6/specification-type "programme"})))))))

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/rio_test.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/rio_test.clj
@@ -61,62 +61,63 @@
     "12345678-9abc-def0-1234-56789abcdef0"))
 
 (deftest test-and-validate-entities
-  (are [updated]
-       (is (-> updated
-               (helper/test-handler test-resolver ooapi.loader/ooapi-file-loader)
-               (prep-body)
-               (soap/guard-valid-sexp mutator/validator)))
+  (helper/with-ooapi-loader ooapi.loader/ooapi-file-loader
+    (are [updated]
+         (is (-> updated
+                 (helper/test-handler test-resolver)
+                 (prep-body)
+                 (soap/guard-valid-sexp mutator/validator)))
 
-    {::ooapi/id "10010000-0000-0000-0000-000000000000"
-     ::ooapi/type "programme"
-     :rio-type :oe
-     :client-id "rio-mapper-dev.jomco.nl"}
-    {::ooapi/id "10020000-0000-0000-0000-000000000000"
-     ::ooapi/type "programme"
-     :rio-type :oe
-     :client-id "rio-mapper-dev.jomco.nl"}
-    {::ooapi/id "10030000-0000-0000-0000-000000000000"
-     ::ooapi/type "programme"
-     :rio-type :oe
-     :client-id "rio-mapper-dev.jomco.nl"}
-    {::ooapi/id "10040000-0000-0000-0000-000000000000"
-     ::ooapi/type "programme"
-     :rio-type :oe
-     :client-id "rio-mapper-dev.jomco.nl"}
-    {::ooapi/id "20010000-0000-0000-0000-000000000000"
-     ::ooapi/type "programme"
-     :rio-type :ao
-     :client-id "rio-mapper-dev.jomco.nl"}
-    {::ooapi/id "20020000-0000-0000-0000-000000000000"
-     ::ooapi/type "programme"
-     :rio-type :ao
-     :client-id "rio-mapper-dev.jomco.nl"}
-    {::ooapi/id "20030000-0000-0000-0000-000000000000"
-     ::ooapi/type "programme"
-     :rio-type :ao
-     :client-id "rio-mapper-dev.jomco.nl"}
-    {::ooapi/id "20030000-0000-0000-0000-000000000000"
-     ::ooapi/type "programme"
-     :rio-type :ao
-     :client-id "rio-mapper-dev.jomco.nl"}
-    {::ooapi/id "30010000-0000-0000-0000-000000000000"
-     ::ooapi/type "course"
-     :rio-type :ao
-     :client-id "rio-mapper-dev.jomco.nl"}))
+      {::ooapi/id "10010000-0000-0000-0000-000000000000"
+       ::ooapi/type "programme"
+       :rio-type :oe
+       :client-id "rio-mapper-dev.jomco.nl"}
+      {::ooapi/id "10020000-0000-0000-0000-000000000000"
+       ::ooapi/type "programme"
+       :rio-type :oe
+       :client-id "rio-mapper-dev.jomco.nl"}
+      {::ooapi/id "10030000-0000-0000-0000-000000000000"
+       ::ooapi/type "programme"
+       :rio-type :oe
+       :client-id "rio-mapper-dev.jomco.nl"}
+      {::ooapi/id "10040000-0000-0000-0000-000000000000"
+       ::ooapi/type "programme"
+       :rio-type :oe
+       :client-id "rio-mapper-dev.jomco.nl"}
+      {::ooapi/id "20010000-0000-0000-0000-000000000000"
+       ::ooapi/type "programme"
+       :rio-type :ao
+       :client-id "rio-mapper-dev.jomco.nl"}
+      {::ooapi/id "20020000-0000-0000-0000-000000000000"
+       ::ooapi/type "programme"
+       :rio-type :ao
+       :client-id "rio-mapper-dev.jomco.nl"}
+      {::ooapi/id "20030000-0000-0000-0000-000000000000"
+       ::ooapi/type "programme"
+       :rio-type :ao
+       :client-id "rio-mapper-dev.jomco.nl"}
+      {::ooapi/id "20030000-0000-0000-0000-000000000000"
+       ::ooapi/type "programme"
+       :rio-type :ao
+       :client-id "rio-mapper-dev.jomco.nl"}
+      {::ooapi/id "30010000-0000-0000-0000-000000000000"
+       ::ooapi/type "course"
+       :rio-type :ao
+       :client-id "rio-mapper-dev.jomco.nl"})))
 
 ;; eigenNaamInternationaal is over 225 chars, which is > max-length
 ;; but no exception, since fields gets truncated.
 (deftest test-and-validate-program-4-valid
-  (let [request (helper/test-handler {::ooapi/id "29990000-0000-0000-0000-000000000000"
-                                      ::ooapi/type "programme"
-                                      :client-id "rio-mapper-dev.jomco.nl"}
-                                     test-resolver
-                                     ooapi.loader/ooapi-file-loader)]
-    (is (= :duo:aanleveren_aangebodenOpleiding_request
-           (first (-> request
-                      prep-body
-                      (soap/guard-valid-sexp mutator/validator))))
-        "guard throws an exception if XML invalid according to XSD")))
+  (helper/with-ooapi-loader ooapi.loader/ooapi-file-loader
+    (let [request (helper/test-handler {::ooapi/id "29990000-0000-0000-0000-000000000000"
+                                        ::ooapi/type "programme"
+                                        :client-id "rio-mapper-dev.jomco.nl"}
+                                       test-resolver)]
+      (is (= :duo:aanleveren_aangebodenOpleiding_request
+             (first (-> request
+                        prep-body
+                        (soap/guard-valid-sexp mutator/validator))))
+          "guard throws an exception if XML invalid according to XSD"))))
 
 (defn collect-paths
   "If leaf-node, add current path (and node if include-leaves is true) to acc.
@@ -258,9 +259,10 @@
              volatile-paths)))))
 
 (defn- test-loader [id ooapi-type]
-  (->> {::ooapi/id id ::ooapi/type ooapi-type}
-       (ooapi.loader/load-entities ooapi.loader/ooapi-file-loader)
-       ::ooapi/entity))
+  (helper/with-ooapi-loader ooapi.loader/ooapi-file-loader
+    (->> {::ooapi/id id ::ooapi/type ooapi-type}
+         (ooapi.loader/load-entities nil)
+         ::ooapi/entity)))
 
 (deftest to-rio-obj
   (testing "prgspec"
@@ -450,11 +452,12 @@
               [:duo:kenmerken [:duo:kenmerknaam "vorm"] [:duo:kenmerkwaardeEnumeratiewaarde "VOLTIJD"]]
               [:duo:kenmerken [:duo:kenmerknaam "voertaal"] [:duo:kenmerkwaardeEnumeratiewaarde "NLD"]]]
 
-             (-> (ooapi.loader/load-entities
-                  mode-of-delivery-loader
-                  {::ooapi/id "20010000-0000-0000-0000-000000000000" ::ooapi/type "programme"})
-                 ::ooapi/entity
-                 (aangeboden-opl/->aangeboden-opleiding :programme "1234O1234" {::ooapi-v6/specification-type "programme"}))))))
+             (helper/with-ooapi-loader mode-of-delivery-loader
+               (-> (ooapi.loader/load-entities
+                    nil
+                    {::ooapi/id "20010000-0000-0000-0000-000000000000" ::ooapi/type "programme"})
+                   ::ooapi/entity
+                   (aangeboden-opl/->aangeboden-opleiding :programme "1234O1234" {::ooapi-v6/specification-type "programme"})))))))
 
   (testing "private program does not include nlqf and eqf fields"
     (let [result (-> {::ooapi/id "10020000-0000-0000-0000-000000000000" ::ooapi/type "programme" :rio-type :oe}

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/test_helper.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/test_helper.clj
@@ -56,20 +56,18 @@
   "Temporarily overrides the OOAPI HTTP loader with the given function."
   [loader & body]
   `(let [loader-fn# ~loader]
-     (with-redefs [ooapi.loader/ooapi-http-load (fn [request# _config#]
+     (with-redefs [ooapi.loader/ooapi-http-loader (fn [request#]
                                                  (loader-fn# request#))]
        ~@body)))
 
 (defn test-handler
   "Loads ooapi fixtures from file and fakes resolver."
-  ([req resolver]
-   (test-handler req resolver nil))
-  ([{::ooapi/keys [type] :as req} resolver ooapi-loader-config]
-   (-> (cond->> (merge req test-client-info)
-         (not= "relation" type)
-         (ooapi.loader/load-entities ooapi-loader-config))
-       (test-resolve-request resolver)
-       updated-handler/update-mutation)))
+  [{::ooapi/keys [type] :as req} resolver]
+  (-> (cond->> (merge req test-client-info)
+        (not= "relation" type)
+        (ooapi.loader/load-entities))
+      (test-resolve-request resolver)
+      updated-handler/update-mutation))
 
 (defn wait-while-predicate [predicate val-atom max-sec]
   (loop [ttl (* max-sec 10)]

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/test_helper.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/test_helper.clj
@@ -52,14 +52,24 @@
                        :institution-schac-home "demo06.test.surfeduhub.nl"
                        :institution-oin        "0000000700025BE00000"})
 
+(defmacro with-ooapi-loader
+  "Temporarily overrides the OOAPI HTTP loader with the given function."
+  [loader & body]
+  `(let [loader-fn# ~loader]
+     (with-redefs [ooapi.loader/ooapi-http-load (fn [request# _config#]
+                                                 (loader-fn# request#))]
+       ~@body)))
+
 (defn test-handler
   "Loads ooapi fixtures from file and fakes resolver."
-  [{::ooapi/keys [type] :as req} resolver ooapi-loader]
-  (-> (cond->> (merge req test-client-info)
-        (not= "relation" type)
-        (ooapi.loader/load-entities ooapi-loader))
-      (test-resolve-request resolver)
-      updated-handler/update-mutation))
+  ([req resolver]
+   (test-handler req resolver nil))
+  ([{::ooapi/keys [type] :as req} resolver ooapi-loader-config]
+   (-> (cond->> (merge req test-client-info)
+         (not= "relation" type)
+         (ooapi.loader/load-entities ooapi-loader-config))
+       (test-resolve-request resolver)
+       updated-handler/update-mutation)))
 
 (defn wait-while-predicate [predicate val-atom max-sec]
   (loop [ttl (* max-sec 10)]


### PR DESCRIPTION
The wrapper pattern is very hard to follow. Let's use a function instead and use with-redefs for overrides in tests.