### PR TITLE
NVD cache fix

### DIFF
--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -28,8 +28,8 @@ jobs:
         path: "~/.m2/repository"
         key: "${{ runner.os }}-clojure-${{ hashFiles('**/deps.edn') }}"
 
-    - name: Cache NVD database
-      uses: actions/cache@v5
+    - name: Restore NVD database
+      uses: actions/cache/restore@v5
       with:
         path: "~/.m2/repository/org/owasp/dependency-check-utils/*/data"
         key: "${{ runner.os }}-nvd"
@@ -52,3 +52,10 @@ jobs:
         CLJ_WATSON_NVD_API_KEY: ${{ secrets.NVD_API_TOKEN }}
       run: |
         make watson
+
+    - name: Save NVD database
+      if: always()
+      uses: actions/cache/save@v5
+      with:
+        path: "~/.m2/repository/org/owasp/dependency-check-utils/*/data"
+        key: "${{ runner.os }}-nvd"

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -54,7 +54,6 @@ jobs:
         make watson
 
     - name: Save NVD database
-      if: always()
       uses: actions/cache/save@v5
       with:
         path: "~/.m2/repository/org/owasp/dependency-check-utils/*/data"

--- a/.github/workflows/test-rio.yml
+++ b/.github/workflows/test-rio.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: '21'
 
       - name: Get status of previous run of this workflow - store in last_status
-        uses: Mercymeilya/last-workflow-status@v0.3.3
+        uses: Mercymeilya/last-workflow-status@v0.3
         id: last_status
 
       - name: Checkout code

--- a/deps.edn
+++ b/deps.edn
@@ -1,20 +1,20 @@
 {:paths ["src-v5" "src-common" "resources"]
  :deps  {org.clojure/clojure      {:mvn/version "1.12.4"}
-         org.clojure/core.async   {:mvn/version "1.8.741"}
+         org.clojure/core.async   {:mvn/version "1.9.865"}
          org.clojure/core.memoize {:mvn/version "1.2.281"}
 
          ;; data
          org.clojure/data.json       {:mvn/version "2.5.2"}
          org.clojure/data.xml        {:mvn/version "0.0.8"}
          org.apache.santuario/xmlsec {:mvn/version "4.0.4"}
-         cheshire/cheshire           {:mvn/version "6.1.0"}
+         cheshire/cheshire           {:mvn/version "6.2.0"}
          commons-io/commons-io       {:mvn/version "2.21.0"}
          commons-codec/commons-codec {:mvn/version "1.21.0"}
          com.velisco/strgen          {:mvn/version "0.2.5" :exclusions [org.clojure/clojurescript]}
 
          ;; http
-         ring/ring-core                 {:mvn/version "1.15.3"}
-         ring/ring-jetty-adapter        {:mvn/version "1.15.3"
+         ring/ring-core                 {:mvn/version "1.15.4"}
+         ring/ring-jetty-adapter        {:mvn/version "1.15.4"
                                          :exclusions  [org.eclipse.jetty/jetty-server
                                                        org.eclipse.jetty/jetty-unixdomain-server
                                                        org.eclipse.jetty.ee9/jetty-ee9-servlet
@@ -25,10 +25,10 @@
          nl.jomco/clj-http-status-codes {:mvn/version "0.2"}
 
          ;; Fixes CVE-2025-11143 and CVE-2026-1605
-         org.eclipse.jetty/jetty-server                                   {:mvn/version "12.1.7"}
-         org.eclipse.jetty/jetty-unixdomain-server                        {:mvn/version "12.1.7"}
-         org.eclipse.jetty.ee9/jetty-ee9-servlet                          {:mvn/version "12.1.7"}
-         org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server {:mvn/version "12.1.7"}
+         org.eclipse.jetty/jetty-server                                   {:mvn/version "12.1.8"}
+         org.eclipse.jetty/jetty-unixdomain-server                        {:mvn/version "12.1.8"}
+         org.eclipse.jetty.ee9/jetty-ee9-servlet                          {:mvn/version "12.1.8"}
+         org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server {:mvn/version "12.1.8"}
 
          ;; interface
          nl.jomco/envopts     {:mvn/version "0.0.7"}
@@ -41,8 +41,8 @@
          ch.qos.logback.contrib/logback-jackson      {:mvn/version "0.1.5"}
          ch.qos.logback.contrib/logback-json-classic {:mvn/version "0.1.5"}
          ch.qos.logback/logback-classic              {:mvn/version "1.5.32"}
-         com.fasterxml.jackson.core/jackson-core     {:mvn/version "2.21.1"}
-         com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.1"}
+         com.fasterxml.jackson.core/jackson-core     {:mvn/version "2.21.2"}
+         com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.2"}
          com.github.steffan-westcott/clj-otel-api    {:mvn/version "0.2.10"}}
 
  :aliases


### PR DESCRIPTION
Currently, if the update nvd step fails (which it does regularly due to downtime), the cache still gets saved (and therefore blown).

Github cache shows entries like:

3821919522  Linux-nvd-24569806915                                                           213 B       about 2 days ago    about 2 days ago

That leads to a cache restore like:

Cache hit for restore-key: Linux-nvd-24552397377
Received 205 of 205 (100.0%), 0.0 MBs/sec
Cache Size: ~0 MB (205 B)


Only save if the update is successful.
