### PR TITLE
Fix cache key

### DIFF
--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -34,7 +34,7 @@ jobs:
         path: "~/.m2/repository/org/owasp/dependency-check-utils/*/data"
         key: "${{ runner.os }}-nvd"
         restore-keys: |
-          ${{ runner.os }}-nvd-
+          ${{ runner.os }}-nvd
 
     - name: Install clj runtime
       run: |


### PR DESCRIPTION
Cache key has trailing dash.

Cache not found for input keys: Linux-nvd-24569806915, Linux-nvd-

Removed trailing cache in cache restore action.
