### PR TITLE
Suppress nvd warnings

### DIFF
--- a/.nvd-suppressions.xml
+++ b/.nvd-suppressions.xml
@@ -14,4 +14,16 @@
     <!-- Related to the Jetty HttpURI class. The HttpURI class does insufficient validation on the authority segment of a URI.
          We don't use the HttpURI class or the authority segment of an URI. -->
   </suppress>
+  <suppress>
+    <notes>opentelemetry-semconv (transitive via clj-otel-api) provides semantic-convention constants only; no patched version available.</notes>
+    <cve>CVE-2026-39882</cve>
+  </suppress>
+  <suppress>
+    <notes>opentelemetry-semconv (transitive via clj-otel-api) provides semantic-convention constants only; no patched version available.</notes>
+    <cve>CVE-2026-39883</cve>
+  </suppress>
+  <suppress>
+    <notes>opentelemetry-semconv (transitive via clj-otel-api) provides semantic-convention constants only; no patched version available.</notes>
+    <cve>CVE-2026-29181</cve>
+  </suppress>
 </suppressions>

--- a/deps.edn
+++ b/deps.edn
@@ -34,7 +34,8 @@
          nl.jomco/envopts     {:mvn/version "0.0.7"}
          clj-http/clj-http    {:mvn/version "3.13.1"}
          clj-time/clj-time    {:mvn/version "0.15.2"}
-         com.taoensso/carmine {:mvn/version "3.5.0" :exclusions [org.clojure/tools.reader]}
+         com.taoensso/carmine {:mvn/version "3.5.0" :exclusions [org.clojure/tools.reader com.taoensso/nippy]}
+         com.taoensso/nippy   {:mvn/version "3.7.0-beta1"}
 
          ;; logging
          org.clojure/tools.logging                   {:mvn/version "1.3.1"}


### PR DESCRIPTION
False positives - warning is about opentelemetry-go.