### PR TITLE
Delete RIO object missing from OOAPI

### DIFF
--- a/.github/workflows/ancient.yml
+++ b/.github/workflows/ancient.yml
@@ -18,7 +18,7 @@ jobs:
         java-version: '21'
 
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Cache maven repository
       uses: actions/cache@v5

--- a/.github/workflows/docker-v5.yml
+++ b/.github/workflows/docker-v5.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.0
+        uses: sigstore/cosign-installer@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Docker meta

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: actions/cache@v5
       with: { path: "~/.m2", key: "${{ runner.os }}-m2" }
 

--- a/.github/workflows/nvd.yml
+++ b/.github/workflows/nvd.yml
@@ -20,7 +20,7 @@ jobs:
         java-version: '21'
 
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Cache maven repository
       uses: actions/cache@v5

--- a/.github/workflows/test-rio.yml
+++ b/.github/workflows/test-rio.yml
@@ -23,7 +23,7 @@ jobs:
         id: last_status
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cache maven repository
         uses: actions/cache@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         distribution: 'temurin'
         java-version: '21'
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - uses: actions/cache@v5
       with: { path: "~/.m2", key: "${{ runner.os }}-m2" }
@@ -38,7 +38,7 @@ jobs:
         distribution: 'temurin'
         java-version: '21'
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - uses: actions/cache@v5
       with: { path: "~/.m2", key: "${{ runner.os }}-m2" }
@@ -94,7 +94,7 @@ jobs:
         java-version: '21'
 
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: actions/cache@v5
       with: { path: "~/.m2", key: "${{ runner.os }}-m2" }
 
@@ -116,7 +116,7 @@ jobs:
         distribution: 'temurin'
         java-version: '21'
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - uses: actions/cache@v5
       with: { path: "~/.m2", key: "${{ runner.os }}-m2" }
@@ -133,11 +133,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Run docker build
       run: docker build -f Dockerfile.v5 .
 
     - name: Run docker build
       run: docker build -f Dockerfile.v6 .
-      

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/commands/processing.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/commands/processing.clj
@@ -41,8 +41,8 @@
     (when (= "aanleveren_opleidingseenheid" (:action result))
       entity)))
 
-;; TODO better name
-(defn- resolve-no-exception [resolver rio-type ooapi-id institution-oin]
+;; This function wraps the resolver but returns nil if entity not found.
+(defn- resolve-safe [resolver rio-type ooapi-id institution-oin]
   (try
     (resolver rio-type ooapi-id institution-oin)
     (catch Exception _ex
@@ -50,7 +50,7 @@
 
 ;; If resolve not successful, nil is returned or exception thrown.
 (defn- can-resolve? [resolver rio-type ooapi-id institution-oin]
-  (some? (resolve-no-exception resolver rio-type ooapi-id institution-oin)))
+  (some? (resolve-safe resolver rio-type ooapi-id institution-oin)))
 
 (defn- quick-validate-specification [{:keys [consumer] :as entity}]
   (when (nil? (:specificationType consumer))
@@ -71,7 +71,8 @@
              (= "specification" programmeType))
     (quick-validate-specification entity)))
 
-(defn ooapi-http-load-no-exception [request]
+;; This function wraps ooapi.loader/ooapi-http-loader but returns nil if entity not found.
+(defn- ooapi-http-load-safe [request]
   (try
     (ooapi.loader/ooapi-http-loader request)
     (catch ExceptionInfo ex
@@ -88,12 +89,12 @@
     (logging/with-mdc
       {:ooapi-type type :ooapi-id id}
       (assoc request :rio-type
-             (if-let [entity (ooapi-http-load-no-exception request)]
+             (if-let [entity (ooapi-http-load-safe request)]
                (if (and (= "programme" type)
                         (= "specification" (:programmeType entity)))
                  :oe
                  :ao)
-               :both)))))
+               :unknown)))))
 
 ;; in:  {::ooapi/keys [type id] :keys [action institution-name institution-oin institution-schac-home]}
 ;; diff out: {:keys [rio-type] ::ooapi/keys [entity]}
@@ -124,11 +125,8 @@
                               (when ooapi-id
                                 (resolver :oe ooapi-id institution-oin)))
           ao-code         (when-not (= :oe rio-type) (resolver rio-type id institution-oin))]
-      ;; Inserting a course or program while the education
-      ;; specification has not been added to RIO will throw an error.
-      ;; Also throw an error when trying to delete an education specification
-      ;; that cannot be resolved.
-      (when (and (nil? oe-code) (= :ao rio-type) (= "upsert" action))
+      ;; Inserting a course or program while the programme specification has not been added to RIO will throw an error.
+      (when (and (nil? oe-code) (= :ao rio-type))
         (throw (ex-info (str "No 'opleidingseenheid' found in RIO with eigensleutel: " ooapi-id)
                         {:code       oe-code
                          :type       type
@@ -156,42 +154,29 @@
                       ::ooapi/keys [type id entity]
                       ::rio/keys [opleidingscode] :as request}]
     {:pre [institution-oin id rio-type]}
-    (if (= :both rio-type)
+    (if (= :unknown rio-type)
       ;; Special case for deleting unknown rio-type
-      ;; if rio-type is :both, resolve first :oe, and if not found, :ao
+      ;; if rio-type is :unknown, resolve first :oe, and if not found, :ao
       ;; as soon as either is found, continue with that one
       ;; if none is found, abort
-      (let [resolve-for-rio-type (fn [rt] (resolve-no-exception resolver rt id institution-oin))]
+      (let [resolve-for-rio-type (fn [rt] (resolve-safe resolver rt id institution-oin))]
         (if-let [rio-code (resolve-for-rio-type :oe)]
           (assoc request ::rio/opleidingscode rio-code :rio-type :oe)
           (when-let [rio-code (resolve-for-rio-type :ao)]
             (assoc request ::rio/aangeboden-opleiding-code rio-code :rio-type :ao))))
 
       ;; Normal case
-      (let [consumer        (:consumer entity)
-            ooapi-id        (if (= :oe rio-type)
+      (let [ooapi-id        (if (= :oe rio-type)
                               id
                               (-> entity :consumer :specificationId))
             oe-code         (or opleidingscode
                                 (when ooapi-id
                                   (resolver :oe ooapi-id institution-oin)))
             ao-code         (when-not (= :oe rio-type) (resolver rio-type id institution-oin))]
-        ;; Inserting a course or program while the education
-        ;; specification has not been added to RIO will throw an error.
-        ;; Also throw an error when trying to delete an education specification
+        ;; Throw an error when trying to delete an education specification
         ;; that cannot be resolved.
-        (when (and (nil? oe-code) (= :oe rio-type) (= "delete" action))
+        (when (and (nil? oe-code) (= :oe rio-type))
           (throw (ex-info (str "No 'opleidingseenheid' found in RIO with eigensleutel: " ooapi-id)
-                          {:code       oe-code
-                           :type       type
-                           :action     action
-                           :retryable? false})))
-        ;; For variants, we need to check if the eduspec this is a variant of (the parent) actually exists in RIO - if not, abort now
-        (when (and
-               (= rio-type :oe)
-               (some? (:variantOf consumer))
-               (not (can-resolve? resolver :oe (:variantOf consumer) institution-oin)))
-          (throw (ex-info (str "No 'opleidingseenheid' found in RIO for the parent of this variant with eigensleutel: " (:variantOf consumer))
                           {:code       oe-code
                            :type       type
                            :action     action

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/commands/processing.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/commands/processing.clj
@@ -33,19 +33,24 @@
    [nl.surf.eduhub-rio-mapper.v6.commands.link :as link]
    [nl.surf.eduhub-rio-mapper.v6.ooapi.loader :as ooapi.loader]
    [nl.surf.eduhub-rio-mapper.v6.rio.relation-handler :as relation-handler]
-   [nl.surf.eduhub-rio-mapper.v6.rio.updated-handler :as updated-handler]))
+   [nl.surf.eduhub-rio-mapper.v6.rio.updated-handler :as updated-handler])
+  (:import [clojure.lang ExceptionInfo]))
 
 (defn- extract-prgspec-from-result [result]
   (let [entity (:ooapi result)]
     (when (= "aanleveren_opleidingseenheid" (:action result))
       entity)))
 
+;; TODO better name
+(defn- resolve-no-exception [resolver rio-type ooapi-id institution-oin]
+  (try
+    (resolver rio-type ooapi-id institution-oin)
+    (catch Exception _ex
+      nil)))
+
 ;; If resolve not successful, nil is returned or exception thrown.
 (defn- can-resolve? [resolver rio-type ooapi-id institution-oin]
-  (try
-    (some? (resolver rio-type ooapi-id institution-oin))
-    (catch Exception _ex
-      false)))
+  (some? (resolve-no-exception resolver rio-type ooapi-id institution-oin)))
 
 (defn- quick-validate-specification [{:keys [consumer] :as entity}]
   (when (nil? (:specificationType consumer))
@@ -66,6 +71,13 @@
              (= "specification" programmeType))
     (quick-validate-specification entity)))
 
+(defn ooapi-http-load-no-exception [request]
+  (try
+    (ooapi.loader/ooapi-http-loader request)
+    (catch ExceptionInfo ex
+      (when (not= http-status/not-found (:status (ex-data ex)))
+        (throw ex)))))
+
 ;; Only function of this phase is to load programmes in order to distinguish
 ;; programmes from programme-specifications, which are different object in RIO
 (defn- load-ooapi-phase-for-delete [{::ooapi/keys [type id] :as request}]
@@ -75,11 +87,13 @@
     (assoc request :rio-type :ao)
     (logging/with-mdc
       {:ooapi-type type :ooapi-id id}
-      (let [entity (ooapi.loader/ooapi-http-loader request)]
-        (assoc request :rio-type (if (and (= "programme" type)
-                                          (= "specification" (:programmeType entity)))
-                                   :oe
-                                   :ao))))))
+      (assoc request :rio-type
+             (if-let [entity (ooapi-http-load-no-exception request)]
+               (if (and (= "programme" type)
+                        (= "specification" (:programmeType entity)))
+                 :oe
+                 :ao)
+               :both)))))
 
 ;; in:  {::ooapi/keys [type id] :keys [action institution-name institution-oin institution-schac-home]}
 ;; diff out: {:keys [rio-type] ::ooapi/keys [entity]}
@@ -114,8 +128,7 @@
       ;; specification has not been added to RIO will throw an error.
       ;; Also throw an error when trying to delete an education specification
       ;; that cannot be resolved.
-      (when (or (and (nil? oe-code) (= :ao rio-type) (= "upsert" action))
-                (and (nil? oe-code) (= :oe rio-type) (= "delete" action)))
+      (when (and (nil? oe-code) (= :ao rio-type) (= "upsert" action))
         (throw (ex-info (str "No 'opleidingseenheid' found in RIO with eigensleutel: " ooapi-id)
                         {:code       oe-code
                          :type       type
@@ -135,6 +148,58 @@
       (cond-> request
         oe-code (assoc ::rio/opleidingscode oe-code)
         ao-code (assoc ::rio/aangeboden-opleiding-code ao-code)))))
+
+;; in:  {::ooapi/keys [type id entity] :keys [action rio-type institution-name institution-oin institution-schac-home]}
+;; diff out: {::rio/keys [opleidingscode aangeboden-opleiding-code]}
+(defn- make-deleter-resolve-phase [{:keys [resolver]}]
+  (fn resolve-phase [{:keys [institution-oin action rio-type]
+                      ::ooapi/keys [type id entity]
+                      ::rio/keys [opleidingscode] :as request}]
+    {:pre [institution-oin id rio-type]}
+    (if (= :both rio-type)
+      ;; Special case for deleting unknown rio-type
+      ;; if rio-type is :both, resolve first :oe, and if not found, :ao
+      ;; as soon as either is found, continue with that one
+      ;; if none is found, abort
+      (let [resolve-for-rio-type (fn [rt] (resolve-no-exception resolver rt id institution-oin))]
+        (if-let [rio-code (resolve-for-rio-type :oe)]
+          (assoc request ::rio/opleidingscode rio-code :rio-type :oe)
+          (when-let [rio-code (resolve-for-rio-type :ao)]
+            (assoc request ::rio/aangeboden-opleiding-code rio-code :rio-type :ao))))
+
+      ;; Normal case
+      (let [consumer        (:consumer entity)
+            ooapi-id        (if (= :oe rio-type)
+                              id
+                              (-> entity :consumer :specificationId))
+            oe-code         (or opleidingscode
+                                (when ooapi-id
+                                  (resolver :oe ooapi-id institution-oin)))
+            ao-code         (when-not (= :oe rio-type) (resolver rio-type id institution-oin))]
+        ;; Inserting a course or program while the education
+        ;; specification has not been added to RIO will throw an error.
+        ;; Also throw an error when trying to delete an education specification
+        ;; that cannot be resolved.
+        (when (and (nil? oe-code) (= :oe rio-type) (= "delete" action))
+          (throw (ex-info (str "No 'opleidingseenheid' found in RIO with eigensleutel: " ooapi-id)
+                          {:code       oe-code
+                           :type       type
+                           :action     action
+                           :retryable? false})))
+        ;; For variants, we need to check if the eduspec this is a variant of (the parent) actually exists in RIO - if not, abort now
+        (when (and
+               (= rio-type :oe)
+               (some? (:variantOf consumer))
+               (not (can-resolve? resolver :oe (:variantOf consumer) institution-oin)))
+          (throw (ex-info (str "No 'opleidingseenheid' found in RIO for the parent of this variant with eigensleutel: " (:variantOf consumer))
+                          {:code       oe-code
+                           :type       type
+                           :action     action
+                           :retryable? false})))
+
+        (cond-> request
+          oe-code (assoc ::rio/opleidingscode oe-code)
+          ao-code (assoc ::rio/aangeboden-opleiding-code ao-code))))))
 
 ;; in:  {::ooapi/keys [type id entity] :keys [action rio-type institution-name institution-oin institution-schac-home] ::rio/keys [opleidingscode aangeboden-opleiding-code]}
 ;; diff out: {:keys [rio-relations]}
@@ -280,12 +345,13 @@
 
 (defn- wrap-phase [[phase f]]
   (fn [req]
-    (try
-      (f req)
-      (catch Exception ex
-        (throw (ex-info (ex-message ex)
-                        (assoc (ex-data ex) :phase phase)
-                        ex))))))
+    (when req
+      (try
+        (f req)
+        (catch Exception ex
+          (throw (ex-info (ex-message ex)
+                          (assoc (ex-data ex) :phase phase)
+                          ex)))))))
 
 (defn- make-insert [handlers rio-config]
   (let [fs [[:preparing      soap-phase-for-update]
@@ -296,7 +362,7 @@
       {:pre [(:institution-oin request)
              (::ooapi/entity request)]}
       (as-> request $
-        (reduce (fn [req f] (f req)) $ wrapped-fs)
+        (reduce (fn [req f] (or (f req) (reduced nil))) $ wrapped-fs)
         (:mutate-result $)))))
 
 (defn- make-update [handlers {:keys [rio-config] :as config}]
@@ -313,14 +379,14 @@
       {:pre [(:institution-oin request)]}
       (as-> request $
         (assoc $ :config config)
-        (reduce (fn [req f] (f req)) $ wrapped-fs)
+        (reduce (fn [req f] (or (f req) (reduced nil))) $ wrapped-fs)
         (merge (:mutate-result $) (select-keys (:job $) [::rio/aangeboden-opleiding-code]))))))
 
 (defn- make-deleter [handlers
                      {:keys [rio-config] :as config}]
   {:pre [rio-config]}
   (let [fs [[:fetching-ooapi load-ooapi-phase-for-delete]
-            [:resolving      (make-updater-resolve-phase handlers)]
+            [:resolving      (make-deleter-resolve-phase handlers)]
             [:deleting       (make-deleter-prune-relations-phase handlers rio-config)]
             [:preparing      soap-phase-for-delete]
             [:deleting       (make-updater-mutate-rio-phase rio-config)]
@@ -330,7 +396,7 @@
       {:pre [(:institution-oin request)]}
       (as-> request $
         (assoc $ :config config)
-        (reduce (fn [req f] (f req)) $ wrapped-fs)
+        (reduce (fn [req f] (or (f req) (reduced nil))) $ wrapped-fs)
         (:mutate-result $)))))
 
 (defn- dry-run-status [rio-summary ooapi-summary]

--- a/test-v6/nl/surf/eduhub_rio_mapper/v6/e2e_test.clj
+++ b/test-v6/nl/surf/eduhub_rio_mapper/v6/e2e_test.clj
@@ -87,6 +87,28 @@
 (def ^:dynamic bonus-parent-code nil)
 (def ^:dynamic bonus-child-code nil)
 
+(deftest ^:v6-e2e test-delete-programme-after-linking-new-sleutel
+  (binding [last-job (post-job :upsert :programmes "specification-parent-program")
+            parent-code nil
+            generated-sleutel (UUID/randomUUID)
+            original-rio-sleutel nil]
+    (and
+     (is (job-done? last-job))
+     (set! parent-code (job-result-opleidingseenheidcode last-job))
+     (is parent-code)
+     (set! original-rio-sleutel (eigen-opleidingseenheid-sleutel parent-code))
+     (is (string? original-rio-sleutel))
+
+     (set! last-job (post-job :link parent-code :programmes generated-sleutel))
+     (is (job-done? last-job))
+     (is (some? (rio-resolve :oe (str generated-sleutel))))
+
+     ;; In ooapi, there is no programme with key generated-sleutel, so we don't know its rio-type.
+     ;; We try to resolve both oe and ao, and then try to delete the first match.
+     (set! last-job (post-job :delete :programmes generated-sleutel))
+     (is (job-done? last-job))
+     (is (nil? (rio-resolve :oe (str generated-sleutel)))))))
+
 (deftest ^:v6-e2e test-program-with-prgspecs
   ;; insert prgspec "parent-program"
   (binding [last-job (post-job :upsert :programmes "specification-parent-program")


### PR DESCRIPTION
From Trello:

In v5 hebben we het volgende testscenario:
2a. link een niet-bestaand ooapi id aan een RIO O-code
2c. verwijder het RIO object met dit niet-bestaande ooapi id
In v5 mapper werkt dit want er wordt geen ooapi call gedaan bij de delete, in v6 mapper wordt bij de delete wel eerst een ooapi call gedaan die dan dus faalt.

mdemare: 

Als ik een delete call krijg voor programme/ooapi-id dan weet ik niet of ik in RIO een aangeboden opleiding of een opleidingeenheid moet verwijderen. Dat is de functie van de extra ooapi call.

conclusie:

Als er geen OOAPI object terugkomt, delete proberen op zowel aangebodenopleiding als opleidingseenheid