### PR TITLE
Don't validate oeapi requests with a 404 response

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -26,14 +26,14 @@
          clj-time/clj-time        {:mvn/version "0.15.2"}
          clj-http/clj-http    {:mvn/version "3.13.1"}
          com.taoensso/carmine {:mvn/version "3.5.0" :exclusions [org.clojure/tools.reader com.taoensso/nippy io.airlift/aircompressor]}
-         com.taoensso/nippy   {:mvn/version "3.8.0"}
+         com.taoensso/nippy   {:mvn/version "3.8.1"}
          io.airlift/aircompressor {:mvn/version "2.0.3"}
 
          ;; logging
          org.clojure/tools.logging                   {:mvn/version "1.3.1"}
          ch.qos.logback.contrib/logback-jackson      {:mvn/version "0.1.5"}
          ch.qos.logback.contrib/logback-json-classic {:mvn/version "0.1.5"}
-         ch.qos.logback/logback-classic              {:mvn/version "1.6.0"}
+         ch.qos.logback/logback-classic              {:mvn/version "1.6.1"}
          com.fasterxml.jackson.core/jackson-core     {:mvn/version "2.22.1"}
          com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.22.1"}
          com.github.steffan-westcott/clj-otel-api    {:mvn/version "0.2.10"}}

--- a/src-v6/nl/surf/eduhub_rio_mapper/v6/ooapi/loader.clj
+++ b/src-v6/nl/surf/eduhub_rio_mapper/v6/ooapi/loader.clj
@@ -132,15 +132,15 @@
   [handler]
   (fn [{root-url ::ooapi/root-url type ::ooapi/type :as request}]
     {:pre [root-url type]}
-    (let [validate-response (response-validator root-url)
-          response (assoc (handler request) :headers {"content-type" "application/json"})
-          to-be-validated {:request request :response (update response :body walk/stringify-keys)}
-          issues (validate-response to-be-validated [])]
-      (when issues
-        (throw (ex-info "Error validating OOAPI Response"
-                        {:issues issues
-                         :request (redact-sensitive-request-info request)
-                         :response response})))
+    (let [response (assoc (handler request) :headers {"content-type" "application/json"})]
+      (when-not (= http-status/not-found (:status response))
+        (let [validate-response (response-validator root-url)
+              to-be-validated {:request request :response (update response :body walk/stringify-keys)}]
+          (when-let [issues (validate-response to-be-validated [])]
+            (throw (ex-info "Error validating OOAPI Response"
+                            {:issues issues
+                             :request (redact-sensitive-request-info request)
+                             :response response})))))
       response)))
 
 (def ^:private max-pages 50)


### PR DESCRIPTION
In response to https://trello.com/c/Ea1ji8Jy/354-v6-delete-met-een-ooapi-object-dat-niet-bestaat-werkt-niet